### PR TITLE
Add DynamoDB Local docker compose for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,44 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## DynamoDB Local (Docker)
+
+ローカルテスト用に、AWS 公式の DynamoDB Local イメージ（`amazon/dynamodb-local`）を Docker Compose で起動できます。
+
+### 起動 / 停止
+
+```bash
+docker compose -f compose.dynamodb-local.yml up -d
+docker compose -f compose.dynamodb-local.yml ps
+
+# 停止
+docker compose -f compose.dynamodb-local.yml down
+```
+
+### 疎通確認（AWS CLI）
+
+事前に AWS CLI をインストールしている前提です。
+
+```bash
+aws dynamodb list-tables --endpoint-url http://localhost:8000 --region ap-northeast-1
+```
+
+必要ならテーブル作成もできます:
+
+```bash
+aws dynamodb create-table \
+  --endpoint-url http://localhost:8000 \
+  --region ap-northeast-1 \
+  --table-name ExampleTable \
+  --attribute-definitions AttributeName=pk,AttributeType=S \
+  --key-schema AttributeName=pk,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST
+```
+
+### アプリからの接続先
+
+アプリ側の AWS SDK 設定で `endpoint` を `http://localhost:8000` に向けてください（例: 環境変数 `DYNAMODB_ENDPOINT_URL=http://localhost:8000` など）。
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/compose.dynamodb-local.yml
+++ b/compose.dynamodb-local.yml
@@ -1,0 +1,14 @@
+services:
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    container_name: dynamodb-local
+    command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-dbPath", "/home/dynamodblocal/data"]
+    ports:
+      - "8000:8000"
+    volumes:
+      - dynamodb_local_data:/home/dynamodblocal/data
+    working_dir: /home/dynamodblocal
+    restart: unless-stopped
+
+volumes:
+  dynamodb_local_data:


### PR DESCRIPTION
## 概要
ローカルテスト用に、AWS 公式の DynamoDB Local（`amazon/dynamodb-local`）を Docker Compose で起動できるようにしました。

## 変更点
- `compose.dynamodb-local.yml` を追加（DynamoDB Local を `localhost:8000` に公開）
- `README.md` に起動/停止、AWS CLI での疎通確認、テーブル作成例を追記

## 使い方
```bash
docker compose -f compose.dynamodb-local.yml up -d
aws dynamodb list-tables --endpoint-url http://localhost:8000 --region ap-northeast-1
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds local DynamoDB development support.
> 
> - Introduces `compose.dynamodb-local.yml` to run `amazon/dynamodb-local` on `localhost:8000` with a persisted volume and `-sharedDb`
> - Updates `README.md` with start/stop commands, AWS CLI connectivity check, table creation example, and guidance to point SDK `endpoint` to `http://localhost:8000`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec5cd8f38b72b1acebd5b51726cf6dbd66ba1b53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive DynamoDB Local setup guide with Docker Compose instructions, including commands for service startup, connectivity verification, table creation, and application configuration for local development environments.

* **Chores**
  * Added Docker Compose configuration file enabling simplified local DynamoDB service deployment with persistent data storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->