### PR TITLE
feat: クイズ画面を実装 (#8)

### DIFF
--- a/src/app/sets/[id]/quiz/page.tsx
+++ b/src/app/sets/[id]/quiz/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { mockQuizSets } from "@/lib/mock-data";
+import { ProgressBar } from "@/components/ProgressBar";
+import { ChoiceGroup } from "@/components/ChoiceGroup";
+import { StickyNav } from "@/components/StickyNav";
+
+export default function QuizPage() {
+  const params = useParams();
+  const router = useRouter();
+  const setId = params.id as string;
+
+  const set = useMemo(
+    () => mockQuizSets.find((s) => s.id === setId),
+    [setId]
+  );
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+
+  // Not found
+  if (!set) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-800">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">
+            セットが見つかりません
+          </h1>
+          <Link
+            href="/"
+            className="mt-4 inline-block text-indigo-600 hover:underline dark:text-indigo-400"
+          >
+            ダッシュボードに戻る
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const questions = set.questions;
+  const totalQuestions = questions.length;
+  const currentQuestion = questions[currentIndex];
+  const isFirst = currentIndex === 0;
+  const isLast = currentIndex === totalQuestions - 1;
+
+  // Check if all questions are answered
+  const allAnswered = questions.every((q) => answers[q.id] !== undefined);
+
+  const handleSelect = (choiceId: string) => {
+    setAnswers((prev) => ({
+      ...prev,
+      [currentQuestion.id]: choiceId,
+    }));
+  };
+
+  const handlePrev = () => {
+    if (!isFirst) {
+      setCurrentIndex((prev) => prev - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (!isLast) {
+      setCurrentIndex((prev) => prev + 1);
+    }
+  };
+
+  const handleSubmit = () => {
+    // Navigate to result page with answers in query params
+    const answersParam = encodeURIComponent(JSON.stringify(answers));
+    router.push(`/sets/${setId}/result?answers=${answersParam}`);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 pb-24 dark:from-slate-900 dark:to-slate-800 sm:pb-0">
+      <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Header */}
+        <header className="mb-6">
+          <Link
+            href={`/sets/${setId}`}
+            className="inline-flex items-center gap-1 text-sm font-medium text-slate-600 hover:text-indigo-600 dark:text-slate-400 dark:hover:text-indigo-400 transition-colors"
+          >
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+            中止する
+          </Link>
+          <h1 className="mt-2 text-xl font-bold text-slate-900 dark:text-white">
+            {set.title}
+          </h1>
+        </header>
+
+        {/* Progress */}
+        <div className="mb-8">
+          <ProgressBar current={currentIndex + 1} total={totalQuestions} />
+        </div>
+
+        {/* Question */}
+        <article className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-700 dark:bg-slate-800 sm:p-8">
+          <h2 className="mb-6 text-lg font-semibold text-slate-900 dark:text-white sm:text-xl">
+            {currentQuestion.text}
+          </h2>
+
+          <ChoiceGroup
+            choices={currentQuestion.choices}
+            selectedId={answers[currentQuestion.id] ?? null}
+            onSelect={handleSelect}
+          />
+        </article>
+
+        {/* Navigation (Desktop) */}
+        <div className="hidden sm:block">
+          <StickyNav
+            onPrev={handlePrev}
+            onNext={handleNext}
+            onSubmit={handleSubmit}
+            isFirst={isFirst}
+            isLast={isLast}
+            canSubmit={allAnswered}
+          />
+        </div>
+      </div>
+
+      {/* Navigation (Mobile - Sticky) */}
+      <div className="sm:hidden">
+        <StickyNav
+          onPrev={handlePrev}
+          onNext={handleNext}
+          onSubmit={handleSubmit}
+          isFirst={isFirst}
+          isLast={isLast}
+          canSubmit={allAnswered}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ChoiceGroup.tsx
+++ b/src/components/ChoiceGroup.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import type { Choice } from "@/lib/types";
+
+interface ChoiceGroupProps {
+  choices: Choice[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  disabled?: boolean;
+}
+
+export function ChoiceGroup({
+  choices,
+  selectedId,
+  onSelect,
+  disabled = false,
+}: ChoiceGroupProps) {
+  return (
+    <fieldset className="space-y-3">
+      <legend className="sr-only">選択肢</legend>
+      {choices.map((choice) => {
+        const isSelected = selectedId === choice.id;
+        return (
+          <label
+            key={choice.id}
+            className={`
+              flex cursor-pointer items-center gap-4 rounded-xl border-2 p-4 transition-all
+              ${
+                isSelected
+                  ? "border-indigo-600 bg-indigo-50 dark:border-indigo-500 dark:bg-indigo-900/20"
+                  : "border-slate-200 bg-white hover:border-slate-300 dark:border-slate-700 dark:bg-slate-800 dark:hover:border-slate-600"
+              }
+              ${disabled ? "cursor-not-allowed opacity-60" : ""}
+            `}
+          >
+            <input
+              type="radio"
+              name="choice"
+              value={choice.id}
+              checked={isSelected}
+              onChange={() => onSelect(choice.id)}
+              disabled={disabled}
+              className="h-5 w-5 border-slate-300 text-indigo-600 focus:ring-indigo-500 dark:border-slate-600 dark:bg-slate-700"
+            />
+            <span
+              className={`text-base ${
+                isSelected
+                  ? "font-medium text-indigo-900 dark:text-indigo-100"
+                  : "text-slate-700 dark:text-slate-300"
+              }`}
+            >
+              {choice.text}
+            </span>
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,25 @@
+interface ProgressBarProps {
+  current: number;
+  total: number;
+}
+
+export function ProgressBar({ current, total }: ProgressBarProps) {
+  const percentage = total > 0 ? Math.round((current / total) * 100) : 0;
+
+  return (
+    <div className="w-full">
+      <div className="mb-1 flex items-center justify-between text-sm">
+        <span className="font-medium text-slate-700 dark:text-slate-300">
+          Question {current} of {total}
+        </span>
+        <span className="text-slate-500 dark:text-slate-400">{percentage}%</span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-slate-700">
+        <div
+          className="h-full rounded-full bg-indigo-600 transition-all duration-300 ease-out"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/StickyNav.tsx
+++ b/src/components/StickyNav.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+interface StickyNavProps {
+  onPrev: () => void;
+  onNext: () => void;
+  onSubmit: () => void;
+  isFirst: boolean;
+  isLast: boolean;
+  canSubmit: boolean;
+}
+
+export function StickyNav({
+  onPrev,
+  onNext,
+  onSubmit,
+  isFirst,
+  isLast,
+  canSubmit,
+}: StickyNavProps) {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 border-t border-slate-200 bg-white/95 px-4 py-3 backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/95 sm:static sm:mt-8 sm:border-t-0 sm:bg-transparent sm:p-0 sm:backdrop-blur-none">
+      <div className="mx-auto flex max-w-3xl items-center justify-between gap-4">
+        {/* Prev Button */}
+        <button
+          type="button"
+          onClick={onPrev}
+          disabled={isFirst}
+          className={`
+            flex items-center gap-2 rounded-lg px-5 py-3 text-sm font-medium transition-colors
+            ${
+              isFirst
+                ? "cursor-not-allowed text-slate-400 dark:text-slate-600"
+                : "text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+            }
+          `}
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          Prev
+        </button>
+
+        {/* Next / Submit Button */}
+        {isLast ? (
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={!canSubmit}
+            className={`
+              flex items-center gap-2 rounded-lg px-6 py-3 text-sm font-semibold transition-all
+              ${
+                canSubmit
+                  ? "bg-green-600 text-white shadow-lg hover:bg-green-700 hover:shadow-xl"
+                  : "cursor-not-allowed bg-slate-300 text-slate-500 dark:bg-slate-700 dark:text-slate-400"
+              }
+            `}
+          >
+            Submit
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onNext}
+            className="flex items-center gap-2 rounded-lg bg-indigo-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition-all hover:bg-indigo-700 hover:shadow-xl"
+          >
+            Next
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## 概要
Issue #8 に対応し、クイズ画面を実装しました。

## 依存関係
⚠️ この PR は以下の順でマージしてください:
1. #10（ダッシュボード）
2. #11（セット詳細）
3. **この PR**

## 変更点
- `src/components/ProgressBar.tsx`: 進捗バー（Question X of Y）
- `src/components/ChoiceGroup.tsx`: 選択肢のラジオボタングループ
- `src/components/StickyNav.tsx`: Prev/Next/Submit ボタン（モバイルで sticky）
- `src/app/sets/[id]/quiz/page.tsx`: クイズページ

## 機能
- ✅ progress bar で進捗を表示
- ✅ `Question X of Y` の表示
- ✅ ラジオボタンで選択肢を選べる
- ✅ Prev/Next で問題を移動
- ✅ 最終問題では Submit ボタンを表示
- ✅ モバイルでは Prev/Next/Submit が下部に sticky

## 動作確認
- `npm run lint` ✅
- `npm run build` ✅

## スクリーンショット
（起動後に確認: `npm run dev` → http://localhost:3000/sets/aws-cloud-practitioner/quiz）

Closes #8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds the full quiz flow UI and navigation.
> 
> - New `src/app/sets/[id]/quiz/page.tsx` renders a quiz using `mockQuizSets`, tracks answers in local state, supports prev/next, and submits by routing to `/sets/{id}/result?answers=...`
> - Introduces `ProgressBar` to display `Question X of Y` with percentage
> - Adds `ChoiceGroup` radio list with selected/disabled styles
> - Adds `StickyNav` with Prev/Next and Submit (mobile sticky, desktop static)
> - Submit enabled only when all questions are answered
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 558ca6ae65cea8c7916d4040a6c5bb289eee06fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->