### PR TITLE
feat: Issue #20 Authモジュール実装（署名Cookie + bcrypt + ガード）

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+
+import { setSessionCookie } from "@/lib/auth/cookie";
+import { getAuthSecret } from "@/lib/auth/config";
+import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
+import { isValidOrigin } from "@/lib/auth/origin";
+import { verifyPassword } from "@/lib/auth/password";
+import { authInputSchema } from "@/lib/auth/schemas";
+import { createSessionToken } from "@/lib/auth/session-token";
+import { prisma } from "@/lib/db/prisma";
+
+export async function POST(request: Request): Promise<NextResponse> {
+  if (!isValidOrigin(request)) {
+    return messageResponse("forbidden origin", 403);
+  }
+
+  try {
+    const body = await request.json();
+    const parsed = authInputSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return messageResponse(parsed.error.issues[0]?.message ?? "invalid request", 400);
+    }
+
+    const user = await prisma.user.findUnique({
+      where: {
+        email: parsed.data.email,
+      },
+      select: {
+        id: true,
+        passwordHash: true,
+        tokenVersion: true,
+      },
+    });
+
+    if (!user) {
+      return messageResponse("invalid credentials", 401);
+    }
+
+    const passwordMatched = await verifyPassword(parsed.data.password, user.passwordHash);
+
+    if (!passwordMatched) {
+      return messageResponse("invalid credentials", 401);
+    }
+
+    const token = createSessionToken({
+      userId: user.id,
+      tokenVersion: user.tokenVersion,
+      authSecret: getAuthSecret(),
+    });
+
+    const response = NextResponse.json({ message: "ok" }, { status: 200 });
+    setSessionCookie(response, token);
+
+    return response;
+  } catch (error: unknown) {
+    return internalServerErrorResponse(error);
+  }
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import { clearSessionCookie } from "@/lib/auth/cookie";
+import { getUserFromRequest } from "@/lib/auth/guards";
+import { messageResponse } from "@/lib/auth/http";
+import { isValidOrigin } from "@/lib/auth/origin";
+
+export async function POST(request: Request): Promise<NextResponse> {
+  if (!isValidOrigin(request)) {
+    return messageResponse("forbidden origin", 403);
+  }
+
+  const user = await getUserFromRequest(request);
+
+  if (!user) {
+    return messageResponse("unauthorized", 401);
+  }
+
+  const response = NextResponse.json({ message: "ok" }, { status: 200 });
+  clearSessionCookie(response);
+
+  return response;
+}

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
+
+import { setSessionCookie } from "@/lib/auth/cookie";
+import { getAuthSecret } from "@/lib/auth/config";
+import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
+import { isValidOrigin } from "@/lib/auth/origin";
+import { hashPassword } from "@/lib/auth/password";
+import { authInputSchema } from "@/lib/auth/schemas";
+import { createSessionToken } from "@/lib/auth/session-token";
+import { prisma } from "@/lib/db/prisma";
+
+export async function POST(request: Request): Promise<NextResponse> {
+  if (!isValidOrigin(request)) {
+    return messageResponse("forbidden origin", 403);
+  }
+
+  try {
+    const body = await request.json();
+    const parsed = authInputSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return messageResponse(
+        parsed.error.issues[0]?.message ?? "invalid request",
+        400,
+      );
+    }
+
+    const passwordHash = await hashPassword(parsed.data.password);
+
+    const user = await prisma.user.create({
+      data: {
+        email: parsed.data.email,
+        passwordHash,
+      },
+      select: {
+        id: true,
+        tokenVersion: true,
+      },
+    });
+
+    const token = createSessionToken({
+      userId: user.id,
+      tokenVersion: user.tokenVersion,
+      authSecret: getAuthSecret(),
+    });
+
+    const response = NextResponse.json({ message: "ok" }, { status: 201 });
+    setSessionCookie(response, token);
+
+    return response;
+  } catch (error: unknown) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      return messageResponse("email already exists", 409);
+    }
+
+    return internalServerErrorResponse(error);
+  }
+}

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+import { getUserFromRequest } from "@/lib/auth/guards";
+import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
+
+export async function GET(request: Request): Promise<NextResponse> {
+  try {
+    const user = await getUserFromRequest(request);
+
+    if (!user) {
+      return messageResponse("unauthorized", 401);
+    }
+
+    return NextResponse.json(
+      {
+        id: user.id,
+        email: user.email,
+      },
+      { status: 200 },
+    );
+  } catch (error: unknown) {
+    return internalServerErrorResponse(error);
+  }
+}

--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -1,4 +1,8 @@
-export default function MePage() {
+import { requireUser } from "@/lib/auth/guards";
+
+export default async function MePage() {
+  await requireUser();
+
   return (
     <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
       <h1 className="text-xl font-semibold">/me</h1>

--- a/app/quiz/[attemptId]/page.tsx
+++ b/app/quiz/[attemptId]/page.tsx
@@ -1,3 +1,5 @@
+import { requireUser } from "@/lib/auth/guards";
+
 type QuizPageProps = {
   params: Promise<{
     attemptId: string;
@@ -5,6 +7,8 @@ type QuizPageProps = {
 };
 
 export default async function QuizPage({ params }: QuizPageProps) {
+  await requireUser();
+
   const { attemptId } = await params;
 
   return (

--- a/app/select/page.tsx
+++ b/app/select/page.tsx
@@ -1,4 +1,8 @@
-export default function SelectPage() {
+import { requireUser } from "@/lib/auth/guards";
+
+export default async function SelectPage() {
+  await requireUser();
+
   return (
     <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
       <h1 className="text-xl font-semibold">/select</h1>

--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,0 +1,9 @@
+export function getAuthSecret(): string {
+  const authSecret = process.env["AUTH_SECRET"];
+
+  if (!authSecret) {
+    throw new Error("AUTH_SECRET is not set");
+  }
+
+  return authSecret;
+}

--- a/lib/auth/constants.ts
+++ b/lib/auth/constants.ts
@@ -1,0 +1,2 @@
+export const SESSION_COOKIE_NAME = "session";
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;

--- a/lib/auth/cookie.ts
+++ b/lib/auth/cookie.ts
@@ -1,0 +1,23 @@
+import type { NextResponse } from "next/server";
+
+import { SESSION_COOKIE_NAME, SESSION_MAX_AGE_SECONDS } from "@/lib/auth/constants";
+
+export function setSessionCookie(response: NextResponse, token: string): void {
+  response.cookies.set(SESSION_COOKIE_NAME, token, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+}
+
+export function clearSessionCookie(response: NextResponse): void {
+  response.cookies.set(SESSION_COOKIE_NAME, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  });
+}

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -1,0 +1,76 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { getAuthSecret } from "@/lib/auth/config";
+import { prisma } from "@/lib/db/prisma";
+import { SESSION_COOKIE_NAME } from "@/lib/auth/constants";
+import { verifySession } from "@/lib/auth/session";
+
+export type AuthUser = {
+  id: string;
+  email: string;
+  tokenVersion: number;
+};
+
+async function findSessionUser(
+  token: string | undefined,
+): Promise<AuthUser | null> {
+  if (!token) {
+    return null;
+  }
+
+  const payload = verifySession(token, getAuthSecret());
+
+  if (!payload) {
+    return null;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: payload.userId },
+    select: {
+      id: true,
+      email: true,
+      tokenVersion: true,
+    },
+  });
+
+  if (!user) {
+    return null;
+  }
+
+  if (user.tokenVersion !== payload.tokenVersion) {
+    return null;
+  }
+
+  return user;
+}
+
+export async function getCurrentUser(): Promise<AuthUser | null> {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+
+  return findSessionUser(sessionCookie);
+}
+
+export async function getUserFromRequest(
+  request: Request,
+): Promise<AuthUser | null> {
+  const sessionCookie = request.headers
+    .get("cookie")
+    ?.split(";")
+    .map((item) => item.trim())
+    .find((item) => item.startsWith(`${SESSION_COOKIE_NAME}=`))
+    ?.slice(`${SESSION_COOKIE_NAME}=`.length);
+
+  return findSessionUser(sessionCookie);
+}
+
+export async function requireUser(): Promise<AuthUser> {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  return user;
+}

--- a/lib/auth/http.ts
+++ b/lib/auth/http.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export function messageResponse(message: string, status: number): NextResponse {
+  return NextResponse.json({ message }, { status });
+}
+
+export function internalServerErrorResponse(error: unknown): NextResponse {
+  console.error(error);
+  return messageResponse("internal server error", 500);
+}

--- a/lib/auth/origin.ts
+++ b/lib/auth/origin.ts
@@ -1,0 +1,11 @@
+export function isValidOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+
+  if (!origin) {
+    return false;
+  }
+
+  const requestOrigin = new URL(request.url).origin;
+
+  return origin === requestOrigin;
+}

--- a/lib/auth/password.ts
+++ b/lib/auth/password.ts
@@ -1,0 +1,11 @@
+import bcrypt from "bcryptjs";
+
+const PASSWORD_SALT_ROUNDS = 12;
+
+export async function hashPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, PASSWORD_SALT_ROUNDS);
+}
+
+export async function verifyPassword(password: string, passwordHash: string): Promise<boolean> {
+  return bcrypt.compare(password, passwordHash);
+}

--- a/lib/auth/schemas.ts
+++ b/lib/auth/schemas.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const authInputSchema = z.object({
+  email: z.email().trim().toLowerCase(),
+  password: z.string().min(8, "パスワードは8文字以上で入力してください"),
+});
+
+export type AuthInput = z.infer<typeof authInputSchema>;

--- a/lib/auth/session-token.ts
+++ b/lib/auth/session-token.ts
@@ -1,0 +1,17 @@
+import { SESSION_MAX_AGE_SECONDS } from "@/lib/auth/constants";
+import { signSession } from "@/lib/auth/session";
+
+export function createSessionToken(input: {
+  userId: string;
+  tokenVersion: number;
+  authSecret: string;
+}): string {
+  return signSession(
+    {
+      userId: input.userId,
+      tokenVersion: input.tokenVersion,
+      exp: Date.now() + SESSION_MAX_AGE_SECONDS * 1000,
+    },
+    input.authSecret,
+  );
+}

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,0 +1,62 @@
+import crypto from "node:crypto";
+
+export type SessionPayload = {
+  userId: string;
+  tokenVersion: number;
+  exp: number;
+};
+
+function toBase64Url(value: string): string {
+  return Buffer.from(value, "utf-8").toString("base64url");
+}
+
+function fromBase64Url(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf-8");
+}
+
+function createHmacSignature(payloadBase64: string, secret: string): string {
+  return crypto.createHmac("sha256", secret).update(payloadBase64).digest("base64url");
+}
+
+export function signSession(payload: SessionPayload, secret: string): string {
+  const payloadBase64 = toBase64Url(JSON.stringify(payload));
+  const signature = createHmacSignature(payloadBase64, secret);
+
+  return `${payloadBase64}.${signature}`;
+}
+
+export function verifySession(token: string, secret: string): SessionPayload | null {
+  const [payloadBase64, signature] = token.split(".");
+
+  if (!payloadBase64 || !signature) {
+    return null;
+  }
+
+  const expectedSignature = createHmacSignature(payloadBase64, secret);
+  const signatureBuffer = Buffer.from(signature, "utf-8");
+  const expectedSignatureBuffer = Buffer.from(expectedSignature, "utf-8");
+
+  if (signatureBuffer.length !== expectedSignatureBuffer.length) {
+    return null;
+  }
+
+  if (!crypto.timingSafeEqual(signatureBuffer, expectedSignatureBuffer)) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(fromBase64Url(payloadBase64)) as SessionPayload;
+
+    if (!parsed.userId || typeof parsed.tokenVersion !== "number" || typeof parsed.exp !== "number") {
+      return null;
+    }
+
+    if (parsed.exp <= Date.now()) {
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/lib/db/prisma.ts
+++ b/lib/db/prisma.ts
@@ -1,15 +1,41 @@
+import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
+import { Pool } from "pg";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
+  pool: Pool | undefined;
 };
+
+function getDatabaseUrl(): string {
+  const databaseUrl = process.env["DATABASE_URL"];
+
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is not set");
+  }
+
+  return databaseUrl;
+}
+
+const pool =
+  globalForPrisma.pool ??
+  new Pool({
+    connectionString: getDatabaseUrl(),
+  });
+
+const adapter = new PrismaPg(pool);
 
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({
-    log: process.env.NODE_ENV === "development" ? ["query", "warn", "error"] : ["error"],
+    adapter,
+    log:
+      process.env.NODE_ENV === "development"
+        ? ["query", "warn", "error"]
+        : ["error"],
   });
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;
+  globalForPrisma.pool = pool;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,16 @@
       "name": "cloud-assessment",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/adapter-pg": "^7.4.0",
         "@prisma/client": "^7.4.0",
+        "bcryptjs": "^3.0.2",
         "next": "16.1.6",
+        "pg": "^8.16.3",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "zod": "^4.1.5"
       },
       "devDependencies": {
-        "@prisma/adapter-pg": "^7.4.0",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/pg": "^8.15.5",
@@ -22,7 +25,6 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
-        "pg": "^8.16.3",
         "prisma": "^7.4.0",
         "tailwindcss": "^4",
         "tsx": "^4.20.5",
@@ -1772,7 +1774,6 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.4.0.tgz",
       "integrity": "sha512-LWwTHaio0bMxvzahmpwpWqsZM0vTfMqwF8zo06YvILL/o47voaSfKzCVxZw/o9awf4fRgS5Vgthobikj9Dusaw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/driver-adapter-utils": "7.4.0",
@@ -1827,7 +1828,6 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.0.tgz",
       "integrity": "sha512-fZicwzgFHvvPMrRLCUinrsBTdadJsi/1oirzShjmFvNLwtu2DYlkxwRVy5zEGhp85mrEGnLeS/PdNRCdE027+Q==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
@@ -1860,7 +1860,6 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.4.0.tgz",
       "integrity": "sha512-jEyE5LkqZ27Ba/DIOfCGOQl6nKMLxuwJNRceCfh7/LRs46UkIKn3bmkI97MEH2t7zkYV3PGBrUr+6sMJaHvc0A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.4.0"
@@ -3184,6 +3183,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/brace-expansion": {
@@ -6543,7 +6551,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.11.0",
@@ -6571,7 +6578,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
       "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -6579,14 +6585,12 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.11.0.tgz",
       "integrity": "sha512-kecgoJwhOpxYU21rZjULrmrBJ698U2RxXofKVzOn5UDj61BPj/qMb7diYUR1nLScCDbrztQFl1TaQZT0t1EtzQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4.0.0"
@@ -6596,7 +6600,6 @@
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
       "integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
@@ -6606,14 +6609,12 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
       "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pg-int8": "1.0.1",
@@ -6630,7 +6631,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6640,7 +6640,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
@@ -6734,7 +6733,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
       "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -6744,7 +6742,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
       "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6754,7 +6751,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6764,7 +6760,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
@@ -7412,7 +7407,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -8163,7 +8157,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
@@ -8204,7 +8197,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -13,13 +13,16 @@
     "db:seed": "prisma db seed"
   },
   "dependencies": {
+    "@prisma/adapter-pg": "^7.4.0",
     "@prisma/client": "^7.4.0",
+    "bcryptjs": "^3.0.2",
     "next": "16.1.6",
+    "pg": "^8.16.3",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "zod": "^4.1.5"
   },
   "devDependencies": {
-    "@prisma/adapter-pg": "^7.4.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/pg": "^8.15.5",
@@ -27,7 +30,6 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
-    "pg": "^8.16.3",
     "prisma": "^7.4.0",
     "tailwindcss": "^4",
     "tsx": "^4.20.5",


### PR DESCRIPTION
## 目的
将来のCognito置換を見据え、認証ロジックを `lib/auth/*` に集約した上で、MVPで必要なサインアップ/ログイン/ログアウトと保護ページガードを実装する。

## 変更内容
- `lib/auth/*` を新規実装
  - `password.ts`: bcryptによるハッシュ/検証
  - `session.ts`: HMAC署名付きセッショントークンの発行/検証
  - `cookie.ts`: `HttpOnly`, `SameSite=Lax`, `Secure(prod)`, `Path=/`, `Max-Age=7日` のCookie操作
  - `guards.ts`: `getCurrentUser()`, `getUserFromRequest()`, `requireUser()`
  - `origin.ts`: 状態変更API向けOriginチェック
  - `schemas.ts`: Zod入力検証
- Auth API追加
  - `POST /api/auth/signup`
  - `POST /api/auth/login`
  - `POST /api/auth/logout`
- 認証確認用API追加
  - `GET /api/me`
- 保護対象ページにガード適用
  - `/select`, `/quiz/[attemptId]`, `/me`
- Prisma 7対応
  - `lib/db/prisma.ts` を `@prisma/adapter-pg` + `pg` ベースへ更新
- 依存追加
  - `bcryptjs`, `zod`, `@prisma/adapter-pg`, `pg`

## 動作確認手順
1. `npm install`
2. `docker-compose up -d`
3. `npm run lint`
4. `npm run build`

## テスト/動作確認結果
- `npm run lint` ✅
- `npm run build` ✅

## 未対応事項
- `/login` 画面UI自体は Issue #21 で実装
- 認証済み状態を使った `/select` の実際のAttempt生成は Issue #22 で実装

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user authentication system with login, signup, and logout functionality
  * Protected pages now require user authentication
  * Added user profile endpoint to retrieve account information
  * Implemented session management with secure HTTP-only cookies

* **Chores**
  * Added authentication and database dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->