### PR TITLE
feat: Issue #21 /login 画面実装（サインアップ/ログイン統合UI + バリデーション）

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,10 +1,179 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type Mode = "login" | "signup";
+
 export default function LoginPage() {
+  const router = useRouter();
+  const [mode, setMode] = useState<Mode>("login");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function validateForm(): string | null {
+    if (!email.trim()) {
+      return "メールアドレスを入力してください";
+    }
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
+      return "有効なメールアドレスを入力してください";
+    }
+
+    if (password.length < 8) {
+      return "パスワードは8文字以上で入力してください";
+    }
+
+    return null;
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError("");
+
+    const validationError = validateForm();
+
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const endpoint =
+        mode === "signup" ? "/api/auth/signup" : "/api/auth/login";
+
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim().toLowerCase(), password }),
+      });
+
+      if (!response.ok) {
+        const data = (await response.json()) as { message?: string };
+
+        if (response.status === 409) {
+          setError("このメールアドレスは既に登録されています");
+        } else if (response.status === 401) {
+          setError("メールアドレスまたはパスワードが正しくありません");
+        } else {
+          setError(
+            data.message ?? "エラーが発生しました。もう一度お試しください",
+          );
+        }
+
+        return;
+      }
+
+      router.push("/select");
+    } catch {
+      setError("通信に失敗しました。ネットワーク接続を確認してください");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function toggleMode() {
+    setMode(mode === "login" ? "signup" : "login");
+    setError("");
+  }
+
   return (
-    <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
-      <h1 className="text-xl font-semibold">/login</h1>
-      <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-300">
-        ログイン/サインアップ画面は Issue #21 で実装します。
-      </p>
-    </section>
+    <div className="flex items-center justify-center py-12">
+      <section className="w-full max-w-md rounded-2xl border border-black/10 bg-white p-8 dark:border-white/15 dark:bg-black/50">
+        <h1 className="mb-6 text-center text-2xl font-semibold">
+          {mode === "login" ? "ログイン" : "アカウント作成"}
+        </h1>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+            >
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="example@email.com"
+              className="w-full rounded-lg border border-neutral-300 bg-transparent px-3 py-2 text-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-neutral-600 dark:focus:border-blue-400 dark:focus:ring-blue-400/20"
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+            >
+              パスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete={
+                mode === "signup" ? "new-password" : "current-password"
+              }
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="8文字以上"
+              className="w-full rounded-lg border border-neutral-300 bg-transparent px-3 py-2 text-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-neutral-600 dark:focus:border-blue-400 dark:focus:ring-blue-400/20"
+              disabled={isSubmitting}
+            />
+          </div>
+
+          {error && (
+            <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="mt-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            {isSubmitting
+              ? "処理中..."
+              : mode === "login"
+                ? "ログイン"
+                : "アカウント作成"}
+          </button>
+        </form>
+
+        <div className="mt-6 text-center text-sm text-neutral-600 dark:text-neutral-400">
+          {mode === "login" ? (
+            <>
+              アカウントをお持ちでない方は{" "}
+              <button
+                type="button"
+                onClick={toggleMode}
+                className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+              >
+                新規登録
+              </button>
+            </>
+          ) : (
+            <>
+              既にアカウントをお持ちの方は{" "}
+              <button
+                type="button"
+                onClick={toggleMode}
+                className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+              >
+                ログイン
+              </button>
+            </>
+          )}
+        </div>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
## 目的
受講者の入口として、サインアップとログインを同一画面で切り替えられる認証UIを提供する。

## 変更内容
- `app/login/page.tsx` を Client Component として全面書き換え
  - ログイン/サインアップのモード切り替え
  - クライアントサイドフォームバリデーション（email形式、password 8文字以上）
  - APIエラーに応じた日本語メッセージ表示
    - 409: メールアドレス重複
    - 401: 認証失敗
    - ネットワークエラー
  - 成功時 `/select` へ遷移
  - 送信中の二重送信防止（disabled + ローディング表示）
  - ダークモード対応（Tailwind CSS）

## 動作確認手順
1. `npm install`
2. `docker-compose up -d`
3. `npm run db:seed`
4. `npm run dev`
5. `/login` にアクセスし以下を確認:
   - 新規登録 → `/select` へ遷移
   - ログイン → `/select` へ遷移
   - バリデーションエラー表示
   - 重複メール/認証失敗エラー表示
   - ダークモードでの視認性

## 実行結果
- `npm run lint` ✅
- `npm run build` ✅

## 未対応事項
- なし

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Complete redesign of login and signup interface with integrated form validation
  * Email and password validation with Japanese error messages
  * Quick toggle between login and signup modes
  * Improved responsive card-style UI with dynamic labels and messaging
  * Enhanced error handling for account registration and authentication failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->