### PR TITLE
feat: Issue #22 /select + Attempt生成API 実装

### DIFF
--- a/app/api/attempts/create/route.ts
+++ b/app/api/attempts/create/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getUserFromRequest } from "@/lib/auth/guards";
+import { isValidOrigin } from "@/lib/auth/origin";
+import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
+import { prisma } from "@/lib/db/prisma";
+
+const createAttemptSchema = z.object({
+  categories: z
+    .array(z.string().min(1))
+    .min(1, "カテゴリを1つ以上選択してください"),
+  level: z.number().int().min(1).max(3),
+  count: z.number().int().min(1).max(50),
+});
+
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    if (!isValidOrigin(request)) {
+      return messageResponse("invalid origin", 403);
+    }
+
+    const user = await getUserFromRequest(request);
+
+    if (!user) {
+      return messageResponse("unauthorized", 401);
+    }
+
+    const body: unknown = await request.json();
+    const parsed = createAttemptSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return messageResponse(
+        parsed.error.issues[0]?.message ?? "invalid input",
+        400,
+      );
+    }
+
+    const { categories, level, count } = parsed.data;
+
+    const questions = await prisma.question.findMany({
+      where: {
+        category: { in: categories },
+        level,
+      },
+      select: { id: true },
+    });
+
+    if (questions.length < count) {
+      return messageResponse(
+        `条件に合う問題が${questions.length}件しかありません（${count}件必要）`,
+        400,
+      );
+    }
+
+    const shuffled = questions.sort(() => Math.random() - 0.5);
+    const selected = shuffled.slice(0, count);
+
+    const attempt = await prisma.$transaction(async (tx) => {
+      const newAttempt = await tx.attempt.create({
+        data: {
+          userId: user.id,
+          filters: { categories, level, count },
+        },
+      });
+
+      await tx.attemptQuestion.createMany({
+        data: selected.map((question, index) => ({
+          attemptId: newAttempt.id,
+          questionId: question.id,
+          order: index + 1,
+        })),
+      });
+
+      return newAttempt;
+    });
+
+    return NextResponse.json({ attemptId: attempt.id }, { status: 201 });
+  } catch (error) {
+    return internalServerErrorResponse(error);
+  }
+}

--- a/app/api/questions/categories/route.ts
+++ b/app/api/questions/categories/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+import { getUserFromRequest } from "@/lib/auth/guards";
+import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
+import { prisma } from "@/lib/db/prisma";
+
+export async function GET(request: Request): Promise<NextResponse> {
+  try {
+    const user = await getUserFromRequest(request);
+
+    if (!user) {
+      return messageResponse("unauthorized", 401);
+    }
+
+    const rows = await prisma.question.groupBy({
+      by: ["category", "level"],
+      _count: { id: true },
+      orderBy: [{ category: "asc" }, { level: "asc" }],
+    });
+
+    const categoryMap = new Map<
+      string,
+      { category: string; levels: number[]; count: number }
+    >();
+
+    for (const row of rows) {
+      const existing = categoryMap.get(row.category);
+
+      if (existing) {
+        if (!existing.levels.includes(row.level)) {
+          existing.levels.push(row.level);
+        }
+        existing.count += row._count.id;
+      } else {
+        categoryMap.set(row.category, {
+          category: row.category,
+          levels: [row.level],
+          count: row._count.id,
+        });
+      }
+    }
+
+    const categories = Array.from(categoryMap.values());
+
+    return NextResponse.json({ categories });
+  } catch (error) {
+    return internalServerErrorResponse(error);
+  }
+}

--- a/app/select/page.tsx
+++ b/app/select/page.tsx
@@ -1,14 +1,9 @@
 import { requireUser } from "@/lib/auth/guards";
 
+import { SelectForm } from "./select-form";
+
 export default async function SelectPage() {
   await requireUser();
 
-  return (
-    <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
-      <h1 className="text-xl font-semibold">/select</h1>
-      <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-300">
-        問題条件選択とAttempt作成は Issue #22 で実装します。
-      </p>
-    </section>
-  );
+  return <SelectForm />;
 }

--- a/app/select/select-form.tsx
+++ b/app/select/select-form.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type CategoryInfo = {
+  category: string;
+  levels: number[];
+  count: number;
+};
+
+export function SelectForm() {
+  const router = useRouter();
+  const [categories, setCategories] = useState<CategoryInfo[]>([]);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [level, setLevel] = useState<number>(1);
+  const [count, setCount] = useState<number>(5);
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    async function fetchCategories() {
+      try {
+        const response = await fetch("/api/questions/categories");
+
+        if (!response.ok) {
+          setError("カテゴリの取得に失敗しました");
+          return;
+        }
+
+        const data = (await response.json()) as { categories: CategoryInfo[] };
+        setCategories(data.categories);
+      } catch {
+        setError("通信に失敗しました");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    void fetchCategories();
+  }, []);
+
+  function toggleCategory(category: string) {
+    setSelectedCategories((prev) =>
+      prev.includes(category)
+        ? prev.filter((c) => c !== category)
+        : [...prev, category],
+    );
+    setError("");
+  }
+
+  function selectAllCategories() {
+    setSelectedCategories(categories.map((c) => c.category));
+    setError("");
+  }
+
+  function deselectAllCategories() {
+    setSelectedCategories([]);
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError("");
+
+    if (selectedCategories.length === 0) {
+      setError("カテゴリを1つ以上選択してください");
+      return;
+    }
+
+    if (count < 1 || count > 50) {
+      setError("問題数は1〜50の範囲で入力してください");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch("/api/attempts/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          categories: selectedCategories,
+          level,
+          count,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = (await response.json()) as { message?: string };
+        setError(data.message ?? "エラーが発生しました");
+        return;
+      }
+
+      const data = (await response.json()) as { attemptId: string };
+      router.push(`/quiz/${data.attemptId}`);
+    } catch {
+      setError("通信に失敗しました。ネットワーク接続を確認してください");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
+        <p className="text-sm text-neutral-600 dark:text-neutral-300">
+          読み込み中...
+        </p>
+      </section>
+    );
+  }
+
+  const isAllSelected =
+    categories.length > 0 &&
+    selectedCategories.length === categories.length;
+
+  return (
+    <section className="mx-auto w-full max-w-2xl rounded-2xl border border-black/10 bg-white p-8 dark:border-white/15 dark:bg-black/50">
+      <h1 className="mb-6 text-2xl font-semibold">問題条件を選択</h1>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+        {/* カテゴリ選択 */}
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <label className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+              カテゴリ
+            </label>
+            <button
+              type="button"
+              onClick={isAllSelected ? deselectAllCategories : selectAllCategories}
+              className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {isAllSelected ? "すべて解除" : "すべて選択"}
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {categories.map((cat) => {
+              const isSelected = selectedCategories.includes(cat.category);
+
+              return (
+                <button
+                  key={cat.category}
+                  type="button"
+                  onClick={() => toggleCategory(cat.category)}
+                  className={`rounded-lg border px-3 py-1.5 text-sm transition ${
+                    isSelected
+                      ? "border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-300"
+                      : "border-neutral-300 text-neutral-600 hover:border-neutral-400 dark:border-neutral-600 dark:text-neutral-400 dark:hover:border-neutral-500"
+                  }`}
+                  disabled={isSubmitting}
+                >
+                  {cat.category}
+                  <span className="ml-1 text-xs opacity-60">({cat.count})</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* レベル選択 */}
+        <div>
+          <label className="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+            レベル
+          </label>
+          <div className="flex gap-2">
+            {[1, 2, 3].map((l) => (
+              <button
+                key={l}
+                type="button"
+                onClick={() => setLevel(l)}
+                className={`rounded-lg border px-4 py-2 text-sm font-medium transition ${
+                  level === l
+                    ? "border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-300"
+                    : "border-neutral-300 text-neutral-600 hover:border-neutral-400 dark:border-neutral-600 dark:text-neutral-400 dark:hover:border-neutral-500"
+                }`}
+                disabled={isSubmitting}
+              >
+                Lv.{l}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 問題数 */}
+        <div>
+          <label
+            htmlFor="count"
+            className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300"
+          >
+            問題数
+          </label>
+          <input
+            id="count"
+            type="number"
+            min={1}
+            max={50}
+            value={count}
+            onChange={(event) => setCount(Number(event.target.value))}
+            className="w-24 rounded-lg border border-neutral-300 bg-transparent px-3 py-2 text-sm outline-none transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-neutral-600 dark:focus:border-blue-400 dark:focus:ring-blue-400/20"
+            disabled={isSubmitting}
+          />
+        </div>
+
+        {error && (
+          <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting || selectedCategories.length === 0}
+          className="rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-600"
+        >
+          {isSubmitting ? "作成中..." : "テストを開始"}
+        </button>
+      </form>
+    </section>
+  );
+}


### PR DESCRIPTION
## 目的
問題セットを条件指定（カテゴリ複数選択・レベル・問題数）から都度Attemptを生成し、クイズ画面へ遷移できるようにする。

## 変更内容

### 新規ファイル
- **`app/api/questions/categories/route.ts`** — `GET /api/questions/categories`
  - 認証済みユーザーのみアクセス可
  - DBからカテゴリ一覧（各カテゴリのlevel分布・問題数）を集計して返却
- **`app/api/attempts/create/route.ts`** — `POST /api/attempts/create`
  - Origin検証 + 認証チェック
  - Zodバリデーション（categories: string[], level: 1-3, count: 1-50）
  - 条件に合う問題をランダム選定し、Attempt + AttemptQuestion をトランザクションで作成
  - 問題不足時は400エラーで具体的なメッセージを返却
- **`app/select/select-form.tsx`** — Client Component
  - カテゴリ複数選択（全選択/全解除）
  - レベル選択（Lv.1 / Lv.2 / Lv.3）
  - 問題数入力（1〜50）
  - エラーメッセージ表示
  - 成功時 `/quiz/[attemptId]` へ遷移
  - ダークモード対応

### 変更ファイル
- **`app/select/page.tsx`** — Server ComponentでrequireUserガード後、SelectFormに委譲

## 動作確認手順
1. `docker-compose up -d`
2. `npm install`
3. `npx prisma migrate dev`
4. `npm run db:seed`
5. `npm run dev`
6. `/login` でログイン → `/select` にアクセス
7. カテゴリ選択・レベル選択・問題数入力 → 「テストを開始」
8. 成功時 `/quiz/[attemptId]` へ遷移することを確認
9. 問題不足時のエラーメッセージ表示を確認

## 実行結果
- `npm run lint` ✅
- `npm run build` ✅

## 未対応事項
- なし

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a quiz customization interface allowing users to select question categories, difficulty levels, and the number of questions to practice before starting
  * Enabled quiz attempt creation and management based on user selections with validation to ensure adequate available questions
  * Added category listing with question counts per difficulty level

<!-- end of auto-generated comment: release notes by coderabbit.ai -->