### PR TITLE
feat(api): 受験結果エクスポートAPI（CSV/JSON）を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ npm run dev
 | -------- | ------------------------------ | ------------ |
 | GET      | `/api/me/attempts`             | 受験履歴一覧 |
 | GET      | `/api/me/attempts/[attemptId]` | 受験履歴詳細 |
+| GET      | `/api/me/attempts/[attemptId]/export?format=csv\|json` | 受験結果エクスポート |
 
 ## セキュリティ
 

--- a/app/api/me/attempts/[attemptId]/export/route.ts
+++ b/app/api/me/attempts/[attemptId]/export/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+
+import { getUserFromRequest } from "@/lib/auth/guards";
+import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
+import { createAttemptExportCsv, createAttemptExportPayload } from "@/lib/attempt/export";
+import { prisma } from "@/lib/db/prisma";
+
+type RouteContext = {
+  params: Promise<{ attemptId: string }>;
+};
+
+const GET = async (
+  request: Request,
+  context: RouteContext,
+): Promise<NextResponse> => {
+  try {
+    const user = await getUserFromRequest(request);
+
+    if (!user) {
+      return messageResponse("unauthorized", 401);
+    }
+
+    const { attemptId } = await context.params;
+    const url = new URL(request.url);
+    const format = url.searchParams.get("format");
+
+    if (format !== "json" && format !== "csv") {
+      return messageResponse("format must be csv or json", 400);
+    }
+
+    const attempt = await prisma.attempt.findUnique({
+      where: { id: attemptId },
+      include: {
+        questions: {
+          orderBy: { order: "asc" },
+          include: {
+            question: {
+              select: {
+                category: true,
+                level: true,
+                questionText: true,
+                choices: true,
+                answerIndex: true,
+                explanation: true,
+              },
+            },
+          },
+        },
+        result: {
+          select: {
+            overallPercent: true,
+            categoryBreakdown: true,
+          },
+        },
+      },
+    });
+
+    if (!attempt) {
+      return messageResponse("attempt not found", 404);
+    }
+
+    if (attempt.userId !== user.id) {
+      return messageResponse("forbidden", 403);
+    }
+
+    const payload = createAttemptExportPayload(attempt);
+
+    if (format === "json") {
+      return NextResponse.json(payload, { status: 200 });
+    }
+
+    const csv = createAttemptExportCsv(payload);
+    const filename = `attempt-${attempt.id}.csv`;
+
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename=\"${filename}\"`,
+      },
+    });
+  } catch (error: unknown) {
+    return internalServerErrorResponse(error);
+  }
+};
+
+export { GET };

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -263,6 +263,44 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/me/attempts/{attemptId}/export:
+    get:
+      tags: [Me]
+      summary: 受験結果エクスポート
+      description: 特定AttemptをJSONまたはCSVでエクスポートする。
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: attemptId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: format
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [json, csv]
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExportAttemptResponse"
+            text/csv:
+              schema:
+                type: string
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
 components:
   securitySchemes:
     cookieAuth:
@@ -539,3 +577,71 @@ components:
             $ref: "#/components/schemas/AttemptQuestionItem"
         result:
           $ref: "#/components/schemas/FinalizeAttemptResponse"
+
+    ExportAttemptQuestion:
+      type: object
+      required:
+        - order
+        - category
+        - level
+        - questionText
+        - choices
+        - answerIndex
+        - explanation
+      properties:
+        order:
+          type: integer
+        category:
+          type: string
+        level:
+          type: integer
+        questionText:
+          type: string
+        choices:
+          type: array
+          items:
+            type: string
+        selectedIndex:
+          type: integer
+          nullable: true
+        answerIndex:
+          type: integer
+        isCorrect:
+          type: boolean
+          nullable: true
+        explanation:
+          type: string
+
+    ExportAttemptResponse:
+      type: object
+      required:
+        - attemptId
+        - status
+        - startedAt
+        - questions
+      properties:
+        attemptId:
+          type: string
+        status:
+          type: string
+          enum: [IN_PROGRESS, COMPLETED]
+        startedAt:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+        overallPercent:
+          type: number
+          format: float
+          nullable: true
+        categoryBreakdown:
+          type: array
+          items:
+            $ref: "#/components/schemas/CategoryBreakdownItem"
+          nullable: true
+        questions:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExportAttemptQuestion"

--- a/lib/attempt/export.ts
+++ b/lib/attempt/export.ts
@@ -1,0 +1,127 @@
+type ExportQuestion = {
+  order: number;
+  selectedIndex: number | null;
+  isCorrect: boolean | null;
+  question: {
+    category: string;
+    level: number;
+    questionText: string;
+    choices: unknown;
+    answerIndex: number;
+    explanation: string;
+  };
+};
+
+type ExportAttempt = {
+  id: string;
+  status: "IN_PROGRESS" | "COMPLETED";
+  startedAt: Date;
+  completedAt: Date | null;
+  result: {
+    overallPercent: number;
+    categoryBreakdown: unknown;
+  } | null;
+  questions: ExportQuestion[];
+};
+
+export type AttemptExportPayload = {
+  attemptId: string;
+  status: "IN_PROGRESS" | "COMPLETED";
+  startedAt: string;
+  completedAt: string | null;
+  overallPercent: number | null;
+  categoryBreakdown: unknown | null;
+  questions: Array<{
+    order: number;
+    category: string;
+    level: number;
+    questionText: string;
+    choices: string[];
+    selectedIndex: number | null;
+    answerIndex: number;
+    isCorrect: boolean | null;
+    explanation: string;
+  }>;
+};
+
+const toStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map((item) => String(item));
+};
+
+export const createAttemptExportPayload = (
+  attempt: ExportAttempt,
+): AttemptExportPayload => {
+  return {
+    attemptId: attempt.id,
+    status: attempt.status,
+    startedAt: attempt.startedAt.toISOString(),
+    completedAt: attempt.completedAt?.toISOString() ?? null,
+    overallPercent: attempt.result?.overallPercent ?? null,
+    categoryBreakdown: attempt.result?.categoryBreakdown ?? null,
+    questions: attempt.questions.map((aq) => ({
+      order: aq.order,
+      category: aq.question.category,
+      level: aq.question.level,
+      questionText: aq.question.questionText,
+      choices: toStringArray(aq.question.choices),
+      selectedIndex: aq.selectedIndex,
+      answerIndex: aq.question.answerIndex,
+      isCorrect: aq.isCorrect,
+      explanation: aq.question.explanation,
+    })),
+  };
+};
+
+const escapeCsv = (value: string): string => {
+  return `"${value.replace(/"/g, '""')}"`;
+};
+
+export const createAttemptExportCsv = (payload: AttemptExportPayload): string => {
+  const header = [
+    "attemptId",
+    "status",
+    "startedAt",
+    "completedAt",
+    "overallPercent",
+    "categoryBreakdown",
+    "order",
+    "category",
+    "level",
+    "questionText",
+    "choices",
+    "selectedIndex",
+    "answerIndex",
+    "isCorrect",
+    "explanation",
+  ].join(",");
+
+  const rows = payload.questions.map((question) => {
+    const columns = [
+      payload.attemptId,
+      payload.status,
+      payload.startedAt,
+      payload.completedAt ?? "",
+      payload.overallPercent === null ? "" : String(payload.overallPercent),
+      payload.categoryBreakdown === null
+        ? ""
+        : JSON.stringify(payload.categoryBreakdown),
+      String(question.order),
+      question.category,
+      String(question.level),
+      question.questionText,
+      question.choices.join(" | "),
+      question.selectedIndex === null ? "" : String(question.selectedIndex),
+      String(question.answerIndex),
+      question.isCorrect === null ? "" : String(question.isCorrect),
+      question.explanation,
+    ];
+
+    return columns.map((column) => escapeCsv(column)).join(",");
+  });
+
+  return [header, ...rows].join("\n");
+};


### PR DESCRIPTION
## 概要
- `GET /api/me/attempts/{attemptId}/export?format=csv|json` を追加しました。
- 認証チェックと所有者チェックを通過したユーザーのみエクスポートできるようにしました。
- `format=json` は構造化JSON、`format=csv` はダウンロード可能なCSVを返します。
- エクスポート変換ロジックを `lib/attempt/export.ts` に分離し、CSVエスケープも実装しました。
- README と OpenAPI に新APIの仕様を追記しました。
- Closes #43

## 変更ファイル
- `app/api/me/attempts/[attemptId]/export/route.ts`
- `lib/attempt/export.ts`
- `README.md`
- `docs/openapi.yaml`

## 動作確認
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx tsx -e "..."` でエクスポートJSON→CSV変換の最低限サニティチェックを実施
- [x] 生成ルート一覧に `/api/me/attempts/[attemptId]/export` が含まれることを確認

Made with [Cursor](https://cursor.com)