### PR TITLE
feat(auth): ログアウト時に全セッション無効化（tokenVersion更新）

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ npm run dev
 
 - **パスワード**: bcryptハッシュ（平文保存禁止）
 - **Cookie**: `HttpOnly`, `SameSite=Lax`, `Secure`(本番), `Path=/`, 7日有効
+- **ログアウト**: `tokenVersion` をインクリメントして既存セッションを無効化
 - **CSRF対策**: 全POST APIでOriginチェック + JSON Content-Type限定
 - **所有者検証**: Attempt更新系APIで `attempt.userId === currentUser.id` を必須チェック
 - **入力検証**: Zodによるサーバーサイドバリデーション

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -2,22 +2,37 @@ import { NextResponse } from "next/server";
 
 import { clearSessionCookie } from "@/lib/auth/cookie";
 import { getUserFromRequest } from "@/lib/auth/guards";
-import { messageResponse } from "@/lib/auth/http";
+import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
 import { isValidOrigin } from "@/lib/auth/origin";
+import { prisma } from "@/lib/db/prisma";
 
 export const POST = async (request: Request): Promise<NextResponse> => {
-  if (!isValidOrigin(request)) {
-    return messageResponse("forbidden origin", 403);
+  try {
+    if (!isValidOrigin(request)) {
+      return messageResponse("forbidden origin", 403);
+    }
+
+    const user = await getUserFromRequest(request);
+
+    if (!user) {
+      return messageResponse("unauthorized", 401);
+    }
+
+    // Invalidate all existing sessions by rotating tokenVersion.
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        tokenVersion: {
+          increment: 1,
+        },
+      },
+    });
+
+    const response = NextResponse.json({ message: "ok" }, { status: 200 });
+    clearSessionCookie(response);
+
+    return response;
+  } catch (error: unknown) {
+    return internalServerErrorResponse(error);
   }
-
-  const user = await getUserFromRequest(request);
-
-  if (!user) {
-    return messageResponse("unauthorized", 401);
-  }
-
-  const response = NextResponse.json({ message: "ok" }, { status: 200 });
-  clearSessionCookie(response);
-
-  return response;
 };


### PR DESCRIPTION
## 概要
- `POST /api/auth/logout` で `tokenVersion` をインクリメントする処理を追加しました。
- これにより、ログアウト時に当該ユーザーの既存セッションを全て無効化します。
- DB更新失敗時に 500 応答へフォールバックするよう、例外ハンドリングを追加しました。
- README のセキュリティ項目に「全セッション無効化」仕様を追記しました。
- Closes #44

## 変更ファイル
- `app/api/auth/logout/route.ts`
- `README.md`

## 動作確認
- [x] `npm run lint`
- [x] `npm run build`
- [x] ログアウトAPIで `tokenVersion` を更新するコードパスを確認
- [x] セキュリティ仕様のドキュメント追記を確認

Made with [Cursor](https://cursor.com)