### PR TITLE
feat(a11y): 認証フォームのエラー関連付けとフォーカス制御を改善

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -29,6 +29,12 @@ const LoginPage = () => {
     emailInputRef.current?.focus();
   }, [mode]);
 
+  useEffect(() => {
+    if (errors.form) {
+      formErrorRef.current?.focus();
+    }
+  }, [errors.form]);
+
   const validateForm = (): FieldErrors => {
     if (!email.trim()) {
       return { email: "メールアドレスを入力してください" };
@@ -97,7 +103,6 @@ const LoginPage = () => {
           });
         }
 
-        formErrorRef.current?.focus();
         return;
       }
 
@@ -106,7 +111,6 @@ const LoginPage = () => {
       setErrors({
         form: "通信に失敗しました。ネットワーク接続を確認してください",
       });
-      formErrorRef.current?.focus();
     } finally {
       setIsSubmitting(false);
     }
@@ -124,7 +128,7 @@ const LoginPage = () => {
           {mode === "login" ? "ログイン" : "アカウント作成"}
         </h1>
 
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
           <div>
             <label
               htmlFor="email"


### PR DESCRIPTION
## 概要
- `/login` のフォームバリデーションをフィールド単位エラーへ変更しました。
- エラーメッセージと入力を `aria-describedby` / `aria-invalid` で関連付けました。
- フォーム送信時のフォーカス制御を追加しました。
  - クライアントバリデーション失敗時: 最初のエラー入力へフォーカス
  - サーバーエラー時: フォームエラー領域へフォーカス
- フォームエラーに `role="alert"` と `aria-live="assertive"` を付与して、読み上げ補助を強化しました。
- Closes #41

## 変更ファイル
- `app/login/page.tsx`

## 動作確認
- [x] `npm run lint`
- [x] `npm run build`
- [x] 入力未設定/形式不正時に該当入力へフォーカスされることを確認
- [x] 401/409/429エラー時にフォームエラーへフォーカスされる実装を確認
- [x] signup時にパスワード要件説明とエラー関連付けが機能する実装を確認

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added password policy UI on signup and conditional display of policy details.

* **Bug Fixes**
  * Per-field error messages and structured form-level feedback.
  * Validation now focuses the first invalid field and clears errors when switching modes.
  * Improved API error handling for authentication, conflicts, rate limits, and network failures.

* **Accessibility**
  * Added ARIA attributes and error associations for better screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->