### PR TITLE
Issue #52: MeページにCSV/JSONエクスポート導線を追加

### DIFF
--- a/app/api/me/attempts/[attemptId]/export/route.ts
+++ b/app/api/me/attempts/[attemptId]/export/route.ts
@@ -66,6 +66,10 @@ export const GET = async (
       return messageResponse("forbidden", 403);
     }
 
+    if (attempt.status !== "COMPLETED" || !attempt.result) {
+      return messageResponse("attempt must be completed before export", 400);
+    }
+
     const payload = createAttemptExportPayload({
       attemptId: attempt.id,
       status: attempt.status,
@@ -76,17 +80,15 @@ export const GET = async (
         level?: number;
         count?: number;
       },
-      result: attempt.result
-        ? {
-            overallPercent: attempt.result.overallPercent,
-            categoryBreakdown: attempt.result.categoryBreakdown as {
-              category: string;
-              total: number;
-              correct: number;
-              percent: number;
-            }[],
-          }
-        : null,
+      result: {
+        overallPercent: attempt.result.overallPercent,
+        categoryBreakdown: attempt.result.categoryBreakdown as {
+          category: string;
+          total: number;
+          correct: number;
+          percent: number;
+        }[],
+      },
       questions: attempt.questions.map((question) => ({
         order: question.order,
         category: question.question.category,

--- a/app/me/me-dashboard.tsx
+++ b/app/me/me-dashboard.tsx
@@ -348,6 +348,7 @@ export const MeDashboard = () => {
               const deliveryState = deliveryStateMap[attempt.id];
               const exportState = exportStateMap[attempt.id];
               const canDeliver = attempt.status === "COMPLETED";
+              const canExport = attempt.status === "COMPLETED";
               const isExporting = exportState?.isExporting === true;
 
               return (
@@ -408,7 +409,7 @@ export const MeDashboard = () => {
                         onClick={() => {
                           void handleExportAttempt(attempt.id, "json");
                         }}
-                        disabled={isExporting}
+                        disabled={!canExport || isExporting}
                         aria-label={`受験 ${attempt.id} の結果をJSONでエクスポート`}
                         className="rounded-lg border border-neutral-300 px-3 py-1.5 text-xs font-medium transition hover:border-neutral-400 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:hover:border-neutral-500"
                       >
@@ -419,7 +420,7 @@ export const MeDashboard = () => {
                         onClick={() => {
                           void handleExportAttempt(attempt.id, "csv");
                         }}
-                        disabled={isExporting}
+                        disabled={!canExport || isExporting}
                         aria-label={`受験 ${attempt.id} の結果をCSVでエクスポート`}
                         className="rounded-lg border border-neutral-300 px-3 py-1.5 text-xs font-medium transition hover:border-neutral-400 disabled:cursor-not-allowed disabled:opacity-50 dark:border-neutral-600 dark:hover:border-neutral-500"
                       >

--- a/lib/attempt/export.ts
+++ b/lib/attempt/export.ts
@@ -81,29 +81,8 @@ export const createAttemptExportPayload = (
 
 export const createAttemptExportCsv = (payload: AttemptExportPayload): string => {
   const lines: string[] = [];
-
-  lines.push("section,key,value");
-  lines.push(`meta,attemptId,${escapeCsvValue(payload.attemptId)}`);
-  lines.push(`meta,status,${escapeCsvValue(payload.status)}`);
-  lines.push(`meta,startedAt,${escapeCsvValue(payload.startedAt)}`);
-  lines.push(`meta,completedAt,${escapeCsvValue(payload.completedAt)}`);
   lines.push(
-    `meta,overallPercent,${escapeCsvValue(payload.result?.overallPercent ?? null)}`,
-  );
-  lines.push(`meta,filters,${escapeCsvValue(JSON.stringify(payload.filters))}`);
-
-  if (payload.result?.categoryBreakdown) {
-    for (const item of payload.result.categoryBreakdown) {
-      lines.push(
-        `categoryBreakdown,${escapeCsvValue(item.category)},${escapeCsvValue(
-          `${item.correct}/${item.total} (${item.percent}%)`,
-        )}`,
-      );
-    }
-  }
-
-  lines.push(
-    "questions,order,category,level,questionText,selectedChoice,answerChoice,isCorrect,explanation",
+    "order,category,level,questionText,selectedChoice,answerChoice,isCorrect,explanation",
   );
 
   for (const question of payload.questions) {
@@ -115,7 +94,6 @@ export const createAttemptExportCsv = (payload: AttemptExportPayload): string =>
 
     lines.push(
       [
-        "question",
         escapeCsvValue(question.order),
         escapeCsvValue(question.category),
         escapeCsvValue(question.level),


### PR DESCRIPTION
## 目的
`/me` ページから受験結果をCSV/JSONで出力できるようにし、完了済みデータのみを連携対象に限定する。

## 変更内容
- 受験履歴行に `JSON出力` / `CSV出力` ボタンを追加
- `GET /api/me/attempts/[attemptId]/export?format=csv|json` を追加
- エクスポートAPIで認証・所有者チェックを実施
- `IN_PROGRESS` のAttemptはExport不可（APIで400、UIもボタン無効）
- Notion連携は既存どおり `COMPLETED` のみ許可
- CSV出力からメタ情報行を削除し、問題明細のみ出力に変更

## テスト計画
- [x] `npm run lint`
- [x] `npm run build`
- [x] `COMPLETED` AttemptでJSON/CSVをダウンロードできること
- [x] `IN_PROGRESS` AttemptでJSON/CSVボタンが無効であること
- [x] `IN_PROGRESS` Attemptへ直接Export APIアクセス時に400になること

## 関連Issue
- #52

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Export quiz attempt results as JSON or CSV files
  * New export buttons added to the attempt dashboard
  * Real-time export status indicators display during processing
  * Supports both JSON and CSV format downloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->