### PR TITLE
Issue #48: Cookie取得処理をNext.js標準APIへ統一

### DIFF
--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -53,14 +53,11 @@ export const getCurrentUser = async (): Promise<AuthUser | null> => {
 };
 
 export const getUserFromRequest = async (
-  request: Request,
+  _request: Request,
 ): Promise<AuthUser | null> => {
-  const sessionCookie = request.headers
-    .get("cookie")
-    ?.split(";")
-    .map((item) => item.trim())
-    .find((item) => item.startsWith(`${SESSION_COOKIE_NAME}=`))
-    ?.slice(`${SESSION_COOKIE_NAME}=`.length);
+  void _request;
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get(SESSION_COOKIE_NAME)?.value;
 
   return findSessionUser(sessionCookie);
 };


### PR DESCRIPTION
## 目的
Route HandlerでのCookie取得処理をNext.js標準APIに統一し、認証ロジックの保守性と実装一貫性を向上させる。

## 変更内容
- `lib/auth/guards.ts` の `getUserFromRequest()` を更新
- 手動の `cookie` ヘッダ文字列パースを廃止
- `cookies()` を利用した `SESSION_COOKIE_NAME` の取得に統一
- `getCurrentUser()` と同一方針のCookie取得へ揃えた

## テスト計画
- [x] `npm run lint`
- [x] `npm run build`
- [x] 認証付きAPIのビルド・型チェックが通ることを確認

## 関連Issue
- #48

Made with [Cursor](https://cursor.com)