### PR TITLE
Issue #65: ログインページの未認証導線を整理しヘッダー表示を修正

### DIFF
--- a/app/header-nav.tsx
+++ b/app/header-nav.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export const HeaderNav = (): React.ReactElement => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const isLoginPage = pathname === "/login";
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoadingAuth, setIsLoadingAuth] = useState(true);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  useEffect(() => {
+    setIsLoadingAuth(true);
+    const fetchMe = async (): Promise<void> => {
+      try {
+        const response = await fetch("/api/me");
+        setIsAuthenticated(response.ok);
+      } catch {
+        setIsAuthenticated(false);
+      } finally {
+        setIsLoadingAuth(false);
+      }
+    };
+
+    void fetchMe();
+  }, [pathname]);
+
+  const handleLogout = async (): Promise<void> => {
+    setIsLoggingOut(true);
+    try {
+      const response = await fetch("/api/auth/logout", { method: "POST" });
+      if (response.ok) {
+        setIsAuthenticated(false);
+        router.push("/login");
+        router.refresh();
+      }
+    } finally {
+      setIsLoggingOut(false);
+    }
+  };
+
+  return (
+    <nav className="flex items-center gap-4 text-sm text-neutral-600 dark:text-neutral-300">
+      {isLoadingAuth ? null : isAuthenticated ? (
+        <button
+          type="button"
+          onClick={() => {
+            void handleLogout();
+          }}
+          disabled={isLoggingOut}
+          className="disabled:opacity-60"
+        >
+          {isLoggingOut ? "Logout..." : "Logout"}
+        </button>
+      ) : (
+        <Link href="/login">Login</Link>
+      )}
+      {!isLoginPage && (
+        <>
+          <Link href="/select">Select</Link>
+          <Link href="/me">Me</Link>
+        </>
+      )}
+    </nav>
+  );
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { HeaderNav } from "./header-nav";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -33,11 +34,7 @@ const RootLayout = ({
             <Link href="/" className="text-sm font-semibold tracking-wide">
               Cloud Assessment
             </Link>
-            <nav className="flex items-center gap-4 text-sm text-neutral-600 dark:text-neutral-300">
-              <Link href="/login">Login</Link>
-              <Link href="/select">Select</Link>
-              <Link href="/me">Me</Link>
-            </nav>
+            <HeaderNav />
           </header>
           <main className="flex-1">{children}</main>
         </div>


### PR DESCRIPTION
## 目的
ログインページで未認証ユーザーに不要な導線（Select / Me）を見せないようにし、
認証状態に応じたヘッダー表示（Login / Logout）を正しく行う。

## 変更内容
- 共通ヘッダーを `HeaderNav` コンポーネントに分離
- `/login` では `Select` / `Me` を非表示
- 認証状態を `/api/me` で判定し、未認証時は `Login`、認証済み時は `Logout` を表示
- `Logout` ボタン押下で `/api/auth/logout` を実行し、`/login` へ遷移
- ページ遷移時（pathname変更時）に認証状態を再判定し、ログイン直後の表示ずれを解消

## テスト計画
- [x] `npm run lint`
- [x] `npm run build`
- [x] `/login` では `Select` / `Me` が表示されないこと
- [x] ログイン後にヘッダーが `Logout` 表示になること
- [x] `Logout` 実行後に `/login` へ戻ること

## 関連Issue
- #65

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Header navigation now dynamically adapts based on authentication status.
  * Quick logout button added to the header for authenticated users.
  * Navigation links intelligently appear based on login state and current page location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->