### PR TITLE
fix(ui): ログアウト後の/api/me 401ノイズを抑止

### DIFF
--- a/app/header-nav.tsx
+++ b/app/header-nav.tsx
@@ -13,6 +13,12 @@ export const HeaderNav = (): React.ReactElement => {
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   useEffect(() => {
+    if (isLoginPage) {
+      setIsAuthenticated(false);
+      setIsLoadingAuth(false);
+      return;
+    }
+
     setIsLoadingAuth(true);
     const fetchMe = async (): Promise<void> => {
       try {
@@ -26,7 +32,7 @@ export const HeaderNav = (): React.ReactElement => {
     };
 
     void fetchMe();
-  }, [pathname]);
+  }, [pathname, isLoginPage]);
 
   const handleLogout = async (): Promise<void> => {
     setIsLoggingOut(true);


### PR DESCRIPTION
/login ではヘッダーの認証確認APIを呼ばないようにし、
ログアウト直後にコンソールへ401が出る挙動を解消しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication state handling on the login page to properly reset and prevent unnecessary API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->