### PR TITLE
fix: Notion連携の重複判定キーを強化して欠損を防止

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ DATABASE_URL="postgresql://postgre:postgre@localhost:5432/cloud_assessment?schem
 AUTH_SECRET="replace-with-32+char-random-string"
 NOTION_API_KEY=""
 NOTION_DATABASE_ID=""
+NOTION_TITLE_PROPERTY_NAME="Name"
 NOTION_DELIVERY_MAX_RETRIES="3"
 NOTION_DELIVERY_RETRY_DELAY_MS="500"
 NOTION_DELIVERY_TIMEOUT_MS="5000"

--- a/README.md
+++ b/README.md
@@ -101,18 +101,18 @@ npm run dev
 
 | カラム名 | 型 | 用途 |
 | --- | --- | --- |
-| `attempt id` | Rich text | Attempt識別子（同一受験の設問を束ねるキー） |
-| `category` | Rich text | 問題カテゴリ |
+| `attempt id` | Text | Attempt識別子（同一受験の設問を束ねるキー） |
+| `category` | Text | 問題カテゴリ |
 | `level` | Number | 難易度 |
-| `questionText` | Title | 問題文（Notion必須のTitleプロパティ） |
-| `selectedChoice` | Rich text | ユーザーが選択した選択肢テキスト |
-| `answerChoice` | Rich text | 正解の選択肢テキスト |
+| `questionText` | Text | 問題文 |
+| `selectedChoice` | Text | ユーザーが選択した選択肢テキスト |
+| `answerChoice` | Text | 正解の選択肢テキスト |
 | `isCorrect` | Checkbox | 正誤 |
-| `explanation` | Rich text | 問題の解説 |
+| `explanation` | Text | 問題の解説 |
 
 補足:
 
-- Notion DatabaseはTitleプロパティ必須のため、`questionText` をTitle型にしてください。
+- Notion DatabaseはTitleプロパティ必須です。8カラムとは別にTitle列を1つ用意し、`.env` の `NOTION_TITLE_PROPERTY_NAME`（デフォルト: `Name`）にその列名を設定してください。
 - Notion連携は受験（Attempt）単位ではなく、設問（Question）単位で1行ずつ保存します。
 
 ## セキュリティ

--- a/docs/notion-delivery.md
+++ b/docs/notion-delivery.md
@@ -8,16 +8,16 @@
 
 | Property Name | Type | Required | 説明 |
 | --- | --- | --- | --- |
-| `attempt id` | Rich text | Yes | Attempt識別子。同一受験の設問を束ねるキー |
-| `category` | Rich text | Yes | 問題カテゴリ |
+| `attempt id` | Text | Yes | Attempt識別子。同一受験の設問を束ねるキー |
+| `category` | Text | Yes | 問題カテゴリ |
 | `level` | Number | Yes | 難易度 |
-| `questionText` | Title | Yes | 問題文（Notion必須のTitleプロパティとして利用） |
-| `selectedChoice` | Rich text | Yes | ユーザーの選択肢テキスト |
-| `answerChoice` | Rich text | Yes | 正解選択肢テキスト |
+| `questionText` | Text | Yes | 問題文 |
+| `selectedChoice` | Text | Yes | ユーザーの選択肢テキスト |
+| `answerChoice` | Text | Yes | 正解選択肢テキスト |
 | `isCorrect` | Checkbox | Yes | 正誤 |
-| `explanation` | Rich text | Yes | 解説 |
+| `explanation` | Text | Yes | 解説 |
 
-> 注: Notion DatabaseにはTitleプロパティが必須のため、`questionText` をTitle型で作成してください。
+> 注: Notion DatabaseにはTitleプロパティが必須です。上記8カラムとは別に、Title列を1つ作成し、`NOTION_TITLE_PROPERTY_NAME`（デフォルト: `Name`）にその列名を設定してください。
 
 ## 環境変数
 
@@ -25,13 +25,14 @@
 | --- | --- | --- |
 | `NOTION_API_KEY` | Yes | Notion Integration Token |
 | `NOTION_DATABASE_ID` | Yes | 書き込み先Database ID |
+| `NOTION_TITLE_PROPERTY_NAME` | No | NotionのTitle列プロパティ名（デフォルト: `Name`） |
 | `NOTION_DELIVERY_MAX_RETRIES` | No | 再送回数（デフォルト: `3`） |
 | `NOTION_DELIVERY_RETRY_DELAY_MS` | No | 初回リトライ待機時間ms（指数バックオフ） |
 | `NOTION_DELIVERY_TIMEOUT_MS` | No | Notion APIタイムアウトms（デフォルト: `5000`） |
 
 ## 冪等性
 
-- `attempt id` + `questionText` の組み合わせで重複判定
+- `attempt id` + `category` + `level` + `questionText` の組み合わせで重複判定
 - 既存レコードがある設問はスキップし、未登録設問のみ作成
 
 ## アプリ -> Notion マッピング

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -281,16 +281,19 @@ paths:
       description: |
         指定Attempt（完了済み）の設問を Notion Database へ送信する（設問単位で1行作成）。
         Notion DB は以下の8カラム構成を前提とする。
-        - `attempt id` (Rich text)
-        - `category` (Rich text)
+        - `attempt id` (Text)
+        - `category` (Text)
         - `level` (Number)
-        - `questionText` (Title)
-        - `selectedChoice` (Rich text)
-        - `answerChoice` (Rich text)
+        - `questionText` (Text)
+        - `selectedChoice` (Text)
+        - `answerChoice` (Text)
         - `isCorrect` (Checkbox)
-        - `explanation` (Rich text)
+        - `explanation` (Text)
 
-        冪等性は `attempt id` + `questionText` の組み合わせで判定し、
+        なお Notion Database の仕様上、別途 Title 列が1つ必要。
+        その列名は `NOTION_TITLE_PROPERTY_NAME`（デフォルト: `Name`）で指定する。
+
+        冪等性は `attempt id` + `category` + `level` + `questionText` の組み合わせで判定し、
         既存の設問行は再作成しない。全設問が既存の場合は `duplicate: true` を返す。
       security:
         - cookieAuth: []


### PR DESCRIPTION
## 目的
Notion連携時に、同一attempt内で1問分が既存判定としてスキップされるケースを防ぎ、設問件数の欠損を起こしにくくするため。

## 変更内容
- Notion送信の重複判定キーを `attempt id + category + level + questionText` に拡張
- `questionText` をText列として扱う仕様に合わせて実装を整合
- Notion必須のTitle列を `NOTION_TITLE_PROPERTY_NAME` で別指定する方針を実装/ドキュメントへ反映
- `docs/notion-delivery.md` と `docs/openapi.yaml` を最新仕様へ更新

## 動作確認
- [x] `npm run lint` が成功すること
- [x] `POST /api/me/attempts/{attemptId}/deliver-notion` が 200 を返すこと
- [x] 重複判定が `attempt id + category + level + questionText` で動作すること

## 補足
- `.cursor/` はローカル補助ファイルのためコミット対象外です。

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notion title column name is now configurable via environment variable, defaulting to "Name".

* **Bug Fixes**
  * Improved deduplication logic for Notion entries to prevent duplicates more accurately.

* **Documentation**
  * Updated Notion integration documentation with standardized column types and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->