### PR TITLE
fix(a11y): エラー通知のライブリージョン対応を画面横断で統一

### DIFF
--- a/app/me/me-dashboard.tsx
+++ b/app/me/me-dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type CategoryScore = {
   category: string;
@@ -71,6 +71,7 @@ export const MeDashboard = () => {
     Record<string, NotionDeliveryState>
   >({});
   const [exportStateMap, setExportStateMap] = useState<Record<string, ExportState>>({});
+  const errorRef = useRef<HTMLParagraphElement>(null);
 
   useEffect(() => {
     const fetchAttempts = async (): Promise<void> => {
@@ -93,6 +94,12 @@ export const MeDashboard = () => {
 
     void fetchAttempts();
   }, []);
+
+  useEffect(() => {
+    if (error) {
+      errorRef.current?.focus();
+    }
+  }, [error]);
 
   const handleSelectAttempt = async (attemptId: string): Promise<void> => {
     setIsDetailLoading(true);
@@ -258,7 +265,13 @@ export const MeDashboard = () => {
       <h1 className="text-2xl font-semibold">マイページ</h1>
 
       {error && (
-        <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+        <p
+          ref={errorRef}
+          tabIndex={-1}
+          role="alert"
+          aria-live="assertive"
+          className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 outline-none dark:bg-red-900/20 dark:text-red-400"
+        >
           {error}
         </p>
       )}

--- a/app/quiz/[attemptId]/quiz-runner.tsx
+++ b/app/quiz/[attemptId]/quiz-runner.tsx
@@ -52,6 +52,7 @@ export const QuizRunner = ({ attemptId }: Props) => {
   const choiceButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const questionNavButtonRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const questionTitleRef = useRef<HTMLHeadingElement>(null);
+  const errorRef = useRef<HTMLParagraphElement>(null);
 
   const fetchAttempt = useCallback(async () => {
     try {
@@ -88,6 +89,12 @@ export const QuizRunner = ({ attemptId }: Props) => {
   useEffect(() => {
     questionTitleRef.current?.focus();
   }, [currentIndex]);
+
+  useEffect(() => {
+    if (error) {
+      errorRef.current?.focus();
+    }
+  }, [error]);
 
   const handleAnswer = async (): Promise<void> => {
     if (selectedChoice === null || !attempt) return;
@@ -269,7 +276,15 @@ export const QuizRunner = ({ attemptId }: Props) => {
   if (error && !attempt) {
     return (
       <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
-        <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        <p
+          ref={errorRef}
+          tabIndex={-1}
+          role="alert"
+          aria-live="assertive"
+          className="text-sm text-red-600 outline-none dark:text-red-400"
+        >
+          {error}
+        </p>
       </section>
     );
   }
@@ -381,7 +396,13 @@ export const QuizRunner = ({ attemptId }: Props) => {
         </div>
 
         {error && (
-          <p className="mt-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+          <p
+            ref={errorRef}
+            tabIndex={-1}
+            role="alert"
+            aria-live="assertive"
+            className="mt-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 outline-none dark:bg-red-900/20 dark:text-red-400"
+          >
             {error}
           </p>
         )}

--- a/app/select/select-form.tsx
+++ b/app/select/select-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type CategoryInfo = {
   category: string;
@@ -18,6 +18,7 @@ export const SelectForm = () => {
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const errorRef = useRef<HTMLParagraphElement>(null);
 
   useEffect(() => {
     const fetchCategories = async (): Promise<void> => {
@@ -40,6 +41,12 @@ export const SelectForm = () => {
 
     void fetchCategories();
   }, []);
+
+  useEffect(() => {
+    if (error) {
+      errorRef.current?.focus();
+    }
+  }, [error]);
 
   const toggleCategory = (category: string): void => {
     setSelectedCategories((prev) =>
@@ -205,7 +212,13 @@ export const SelectForm = () => {
         </div>
 
         {error && (
-          <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+          <p
+            ref={errorRef}
+            tabIndex={-1}
+            role="alert"
+            aria-live="assertive"
+            className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 outline-none dark:bg-red-900/20 dark:text-red-400"
+          >
             {error}
           </p>
         )}


### PR DESCRIPTION
## 目的
主要画面（`/select`・`/quiz/[attemptId]`・`/me`）で、エラー発生時にスクリーンリーダーへ即時通知されるようa11y実装を統一する。

Closes #72

## 変更内容
- エラー表示に `role=\"alert\"` と `aria-live=\"assertive\"` を追加
- エラー表示要素に `tabIndex={-1}` を付与
- エラー発生時に対象要素へフォーカス移動する `useEffect` + `ref` を追加

対象ファイル:
- `app/select/select-form.tsx`
- `app/quiz/[attemptId]/quiz-runner.tsx`
- `app/me/me-dashboard.tsx`

## 動作確認
- [x] `npm run lint`
- [ ] `/select` で入力エラー時に通知されること
- [ ] `/quiz/[attemptId]` で通信/操作エラー時に通知されること
- [ ] `/me` で取得失敗時に通知されること

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now automatically receive focus when displayed, ensuring users are notified of issues.
  * Added accessibility attributes to error message elements across multiple form components.
  * Improved keyboard navigation and screen reader compatibility for error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->