### PR TITLE
fix(a11y): 選択ボタン群に状態属性を付与

### DIFF
--- a/app/select/select-form.tsx
+++ b/app/select/select-form.tsx
@@ -138,12 +138,18 @@ export const SelectForm = () => {
             <button
               type="button"
               onClick={isAllSelected ? deselectAllCategories : selectAllCategories}
+              aria-pressed={isAllSelected}
+              aria-label={
+                isAllSelected
+                  ? "カテゴリの全選択を解除"
+                  : "カテゴリをすべて選択"
+              }
               className="text-xs text-blue-600 hover:underline dark:text-blue-400"
             >
               {isAllSelected ? "すべて解除" : "すべて選択"}
             </button>
           </div>
-          <div className="flex flex-wrap gap-2">
+          <div role="group" aria-label="カテゴリ選択" className="flex flex-wrap gap-2">
             {categories.map((cat) => {
               const isSelected = selectedCategories.includes(cat.category);
 
@@ -152,6 +158,8 @@ export const SelectForm = () => {
                   key={cat.category}
                   type="button"
                   onClick={() => toggleCategory(cat.category)}
+                  aria-pressed={isSelected}
+                  aria-label={`${cat.category}（${cat.count}問）${isSelected ? "選択中" : "未選択"}`}
                   className={`rounded-lg border px-3 py-1.5 text-sm transition ${
                     isSelected
                       ? "border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-300"
@@ -172,12 +180,14 @@ export const SelectForm = () => {
           <label className="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
             レベル
           </label>
-          <div className="flex gap-2">
+          <div role="group" aria-label="レベル選択" className="flex gap-2">
             {[1, 2, 3].map((l) => (
               <button
                 key={l}
                 type="button"
                 onClick={() => setLevel(l)}
+                aria-pressed={level === l}
+                aria-label={`レベル ${l}${level === l ? "（選択中）" : ""}`}
                 className={`rounded-lg border px-4 py-2 text-sm font-medium transition ${
                   level === l
                     ? "border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-300"


### PR DESCRIPTION
## 目的
カテゴリ選択・レベル選択のボタンUIで、選択状態をスクリーンリーダーへ正しく伝える。

Closes #73

## 変更内容
- `/select` のカテゴリ選択ボタンに `aria-pressed` を追加
- `/select` のレベル選択ボタンに `aria-pressed` を追加
- カテゴリ/レベルのボタン群に `role=\"group\"` と `aria-label` を追加
- 全選択/解除ボタンにも `aria-pressed` と `aria-label` を追加

## 動作確認
- [x] `npm run lint`
- [ ] カテゴリボタン押下時に選択状態が支援技術で認識できること
- [ ] レベルボタン押下時に選択状態が支援技術で認識できること

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced accessibility for form controls with improved screen reader support and clearer button state indicators for assistive technology users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->