### PR TITLE
fix: 問題抽出シャッフルをFisher-Yatesへ置換

### DIFF
--- a/app/api/attempts/create/route.ts
+++ b/app/api/attempts/create/route.ts
@@ -14,6 +14,20 @@ const createAttemptSchema = z.object({
   count: z.number().int().min(1).max(50),
 });
 
+const shuffleInPlace = <T>(items: T[]): T[] => {
+  const shuffled = [...items];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    [shuffled[index], shuffled[randomIndex]] = [
+      shuffled[randomIndex],
+      shuffled[index],
+    ];
+  }
+
+  return shuffled;
+};
+
 export const POST = async (request: Request): Promise<NextResponse> => {
   try {
     if (!isValidOrigin(request)) {
@@ -57,7 +71,7 @@ export const POST = async (request: Request): Promise<NextResponse> => {
       );
     }
 
-    const shuffled = questions.sort(() => Math.random() - 0.5);
+    const shuffled = shuffleInPlace(questions);
     const selected = shuffled.slice(0, count);
 
     const attempt = await prisma.$transaction(async (tx) => {


### PR DESCRIPTION
## 目的
Attempt作成時の問題抽出ロジックで使用している `sort(() => Math.random() - 0.5)` を廃止し、偏りの少ないシャッフルへ変更する。

Closes #74

## 変更内容
- `app/api/attempts/create/route.ts` に Fisher-Yates ベースのシャッフル関数を追加
- 問題抽出時のシャッフル処理を `sort(Math.random)` から差し替え
- 抽出件数・レスポンス仕様は維持

## 動作確認
- [x] `npm run lint`
- [ ] `/select` からAttempt作成し、既存どおり指定件数で出題されること

Made with [Cursor](https://cursor.com)