### PR TITLE
feat: マイページ向け学習サマリー統計APIを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ npm run import:questions -- ./path/to/questions.csv
 
 | メソッド | パス                           | 説明         |
 | -------- | ------------------------------ | ------------ |
+| GET      | `/api/me/stats`               | 学習サマリー統計 |
 | GET      | `/api/me/attempts`             | 受験履歴一覧 |
 | GET      | `/api/me/attempts/[attemptId]` | 受験履歴詳細 |
 | POST     | `/api/me/attempts/[attemptId]/deliver-notion` | 対象受験結果をNotionへ送信 |

--- a/app/api/me/stats/route.ts
+++ b/app/api/me/stats/route.ts
@@ -1,0 +1,216 @@
+import { NextResponse } from "next/server";
+
+import { getUserFromRequest } from "@/lib/auth/guards";
+import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
+import { prisma } from "@/lib/db/prisma";
+
+type CategoryAggregate = {
+  total: number;
+  correct: number;
+};
+
+const toDateKey = (date: Date): string => {
+  return date.toISOString().slice(0, 10);
+};
+
+const roundToOneDecimal = (value: number): number => {
+  return Math.round(value * 10) / 10;
+};
+
+const calculateStreakDays = (activityDates: Date[]): number => {
+  if (activityDates.length === 0) {
+    return 0;
+  }
+
+  const activeDays = new Set(activityDates.map((date) => toDateKey(date)));
+  const cursor = new Date();
+  cursor.setUTCHours(0, 0, 0, 0);
+
+  let streakDays = 0;
+  while (activeDays.has(toDateKey(cursor))) {
+    streakDays += 1;
+    cursor.setUTCDate(cursor.getUTCDate() - 1);
+  }
+
+  return streakDays;
+};
+
+const createWeeklyActivityBuckets = (): Array<{ date: string; count: number }> => {
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  return Array.from({ length: 7 }).map((_, index) => {
+    const date = new Date(today);
+    date.setUTCDate(today.getUTCDate() - (6 - index));
+    return {
+      date: toDateKey(date),
+      count: 0,
+    };
+  });
+};
+
+export const GET = async (request: Request): Promise<NextResponse> => {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) {
+      return messageResponse("unauthorized", 401);
+    }
+
+    const [
+      allResults,
+      recentResults,
+      totalAnswered,
+      completedQuestions,
+      answeredQuestions,
+    ] =
+      await Promise.all([
+        prisma.result.findMany({
+          where: {
+            attempt: {
+              userId: user.id,
+            },
+          },
+          select: {
+            overallPercent: true,
+          },
+        }),
+        prisma.result.findMany({
+          where: {
+            attempt: {
+              userId: user.id,
+            },
+          },
+          orderBy: {
+            createdAt: "desc",
+          },
+          take: 10,
+          select: {
+            overallPercent: true,
+          },
+        }),
+        prisma.attemptQuestion.count({
+          where: {
+            attempt: {
+              userId: user.id,
+            },
+            selectedIndex: {
+              not: null,
+            },
+          },
+        }),
+        prisma.attemptQuestion.findMany({
+          where: {
+            attempt: {
+              userId: user.id,
+              status: "COMPLETED",
+            },
+            isCorrect: {
+              not: null,
+            },
+          },
+          select: {
+            isCorrect: true,
+            question: {
+              select: {
+                category: true,
+              },
+            },
+          },
+        }),
+        prisma.attemptQuestion.findMany({
+          where: {
+            attempt: {
+              userId: user.id,
+            },
+            answeredAt: {
+              not: null,
+            },
+          },
+          select: {
+            answeredAt: true,
+          },
+        }),
+      ]);
+
+    const totalAttempts = allResults.length;
+    const averagePercent =
+      totalAttempts === 0
+        ? 0
+        : roundToOneDecimal(
+            allResults.reduce((sum, result) => sum + result.overallPercent, 0) /
+              totalAttempts,
+          );
+    const bestPercent =
+      totalAttempts === 0
+        ? 0
+        : roundToOneDecimal(
+            allResults.reduce((max, result) =>
+              Math.max(max, result.overallPercent),
+            0),
+          );
+
+    const recentAveragePercent =
+      recentResults.length === 0
+        ? 0
+        : roundToOneDecimal(
+            recentResults.reduce((sum, result) => sum + result.overallPercent, 0) /
+              recentResults.length,
+          );
+
+    const allAnsweredAt = answeredQuestions
+      .map((question) => question.answeredAt)
+      .filter((answeredAt): answeredAt is Date => answeredAt instanceof Date);
+    const streakDays = calculateStreakDays(allAnsweredAt);
+
+    const weeklyActivity = createWeeklyActivityBuckets();
+    const weeklyActivityMap = new Map(
+      weeklyActivity.map((item) => [item.date, item]),
+    );
+    for (const answeredAt of allAnsweredAt) {
+      const key = toDateKey(answeredAt);
+      const bucket = weeklyActivityMap.get(key);
+      if (bucket) {
+        bucket.count += 1;
+      }
+    }
+
+    const categoryMap = completedQuestions.reduce<Record<string, CategoryAggregate>>(
+      (acc, question) => {
+        const category = question.question.category;
+        const current = acc[category] ?? { total: 0, correct: 0 };
+        current.total += 1;
+        if (question.isCorrect === true) {
+          current.correct += 1;
+        }
+        acc[category] = current;
+        return acc;
+      },
+      {},
+    );
+
+    const categoryProgress = Object.entries(categoryMap)
+      .map(([category, aggregate]) => ({
+        category,
+        total: aggregate.total,
+        correct: aggregate.correct,
+        percent:
+          aggregate.total === 0
+            ? 0
+            : roundToOneDecimal((aggregate.correct / aggregate.total) * 100),
+      }))
+      .sort((a, b) => a.category.localeCompare(b.category));
+
+    return NextResponse.json({
+      totalAttempts,
+      averagePercent,
+      recentAveragePercent,
+      bestPercent,
+      streakDays,
+      totalAnswered,
+      weeklyActivity,
+      categoryProgress,
+    });
+  } catch (error: unknown) {
+    return internalServerErrorResponse(error);
+  }
+};

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -230,6 +230,23 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/me/stats:
+    get:
+      tags: [Me]
+      summary: 学習サマリー統計取得
+      description: ログインユーザーの全期間・直近の学習サマリー統計を返す。
+      security:
+        - cookieAuth: []
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MeStatsResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /api/me/attempts:
     get:
       tags: [Me]
@@ -568,6 +585,75 @@ components:
         email:
           type: string
           format: email
+
+    WeeklyActivityItem:
+      type: object
+      required: [date, count]
+      properties:
+        date:
+          type: string
+          format: date
+          example: "2026-02-26"
+        count:
+          type: integer
+          minimum: 0
+
+    CategoryProgressItem:
+      type: object
+      required: [category, total, correct, percent]
+      properties:
+        category:
+          type: string
+        total:
+          type: integer
+          minimum: 0
+        correct:
+          type: integer
+          minimum: 0
+        percent:
+          type: number
+          format: float
+
+    MeStatsResponse:
+      type: object
+      required:
+        [
+          totalAttempts,
+          averagePercent,
+          recentAveragePercent,
+          bestPercent,
+          streakDays,
+          totalAnswered,
+          weeklyActivity,
+          categoryProgress,
+        ]
+      properties:
+        totalAttempts:
+          type: integer
+          minimum: 0
+        averagePercent:
+          type: number
+          format: float
+        recentAveragePercent:
+          type: number
+          format: float
+        bestPercent:
+          type: number
+          format: float
+        streakDays:
+          type: integer
+          minimum: 0
+        totalAnswered:
+          type: integer
+          minimum: 0
+        weeklyActivity:
+          type: array
+          items:
+            $ref: "#/components/schemas/WeeklyActivityItem"
+        categoryProgress:
+          type: array
+          items:
+            $ref: "#/components/schemas/CategoryProgressItem"
 
     MyAttemptSummary:
       type: object


### PR DESCRIPTION
## 目的
マイページを総合的に改善する前提として、全期間・直近の学習統計を返す `GET /api/me/stats` を追加する。

Closes #79

## 変更内容
- `app/api/me/stats/route.ts` を追加
  - `totalAttempts`（完了受験数）
  - `averagePercent`（全期間平均）
  - `recentAveragePercent`（直近10回平均）
  - `bestPercent`（最高正答率）
  - `streakDays`（連続学習日数）
  - `totalAnswered`（総回答数）
  - `weeklyActivity`（直近7日の日別回答数）
  - `categoryProgress`（カテゴリ別 total/correct/percent）
- `docs/openapi.yaml` に `/api/me/stats` と関連schemaを追加
- `README.md` のAPI一覧へ `/api/me/stats` を追記

## 動作確認
- [x] `npm run lint`
- [x] 認証なしで `/api/me/stats` にアクセスすると 401
- [x] 認証ありで `/api/me/stats` が統計JSONを返却

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added learning statistics endpoint to track personalized performance metrics, including attempt counts, average scores, learning streaks, weekly activity, and progress by category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->