### PR TITLE
feat: Issue #91 マイページサマリーの文言とKPIを再設計

### DIFF
--- a/app/api/me/stats/route.ts
+++ b/app/api/me/stats/route.ts
@@ -185,6 +185,10 @@ export const GET = async (request: Request): Promise<NextResponse> => {
         heatmapBucket.count += 1;
       }
     }
+    const recent7DaysAnswered = weeklyActivity.reduce(
+      (sum, item) => sum + item.count,
+      0,
+    );
 
     const categoryMap = completedQuestions.reduce<Record<string, CategoryAggregate>>(
       (acc, question) => {
@@ -219,6 +223,7 @@ export const GET = async (request: Request): Promise<NextResponse> => {
       bestPercent,
       streakDays,
       totalAnswered,
+      recent7DaysAnswered,
       weeklyActivity,
       activityHeatmap,
       categoryProgress,

--- a/app/me/me-dashboard.tsx
+++ b/app/me/me-dashboard.tsx
@@ -67,6 +67,7 @@ type MeStats = {
   bestPercent: number;
   streakDays: number;
   totalAnswered: number;
+  recent7DaysAnswered: number;
   weeklyActivity: Array<{
     date: string;
     count: number;
@@ -524,10 +525,10 @@ export const MeDashboard = () => {
           </section>
 
           <section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <SummaryCard label="全体平均" value={`${stats.averagePercent}%`} />
+            <SummaryCard label="全体平均点" value={`${stats.averagePercent}%`} />
             <SummaryCard label="受験回数" value={`${stats.totalAttempts}回`} />
-            <SummaryCard label="直近10回平均" value={`${stats.recentAveragePercent}%`} />
-            <SummaryCard label="最高スコア" value={`${stats.bestPercent}%`} />
+            <SummaryCard label="直近10回平均点" value={`${stats.recentAveragePercent}%`} />
+            <SummaryCard label="直近7日回答数" value={`${stats.recent7DaysAnswered}問`} />
           </section>
 
           <section className="grid grid-cols-1 gap-4 xl:grid-cols-2">

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -642,6 +642,7 @@ components:
           bestPercent,
           streakDays,
           totalAnswered,
+          recent7DaysAnswered,
           weeklyActivity,
           activityHeatmap,
           categoryProgress,
@@ -663,6 +664,9 @@ components:
           type: integer
           minimum: 0
         totalAnswered:
+          type: integer
+          minimum: 0
+        recent7DaysAnswered:
           type: integer
           minimum: 0
         weeklyActivity:


### PR DESCRIPTION
## 目的
Issue #91 対応として、マイページのサマリー指標を直感的に理解しやすい表現へ改善する。

## 変更内容
- サマリー文言を明確化
  - `全体平均` → `全体平均点`
  - `直近10回平均` → `直近10回平均点`
- `最高スコア` カードを廃止
- 代替KPIとして `直近7日回答数` カードを追加
- `/api/me/stats` に `recent7DaysAnswered` を追加
- `docs/openapi.yaml` の `MeStatsResponse` に `recent7DaysAnswered` を追加

## 動作確認
- [x] `npm run lint`
- [x] `npm run build`
- [x] マイページのサマリーカードで文言変更を確認
- [x] 最高スコアカードが消え、直近7日回答数が表示されることを確認

Closes #91

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Recent 7 Days Answers" metric to the user dashboard
  * Improved clarity of dashboard card labels

* **Documentation**
  * Updated API documentation with the new recent answers metric

<!-- end of auto-generated comment: release notes by coderabbit.ai -->