### PR TITLE
fix(security): 受験中の正解情報漏洩防止と回答APIの堅牢化

### DIFF
--- a/app/api/attempts/[attemptId]/answer/route.ts
+++ b/app/api/attempts/[attemptId]/answer/route.ts
@@ -76,6 +76,10 @@ export const POST = async (
       return messageResponse("question not found", 404);
     }
 
+    if (attemptQuestion.selectedIndex !== null) {
+      return messageResponse("この問題は既に回答済みです", 400);
+    }
+
     const isCorrect = selectedIndex === attemptQuestion.question.answerIndex;
 
     const updated = await prisma.attemptQuestion.update({
@@ -90,7 +94,6 @@ export const POST = async (
     return NextResponse.json({
       attemptQuestionId: updated.id,
       selectedIndex: updated.selectedIndex,
-      isCorrect: updated.isCorrect,
     });
   } catch (error) {
     return internalServerErrorResponse(error);

--- a/app/api/me/attempts/[attemptId]/route.ts
+++ b/app/api/me/attempts/[attemptId]/route.ts
@@ -52,19 +52,25 @@ export const GET = async (
       return messageResponse("forbidden", 403);
     }
 
+    const isCompleted = attempt.status === "COMPLETED";
+
     const questions = attempt.questions.map((aq) => ({
       attemptQuestionId: aq.id,
       order: aq.order,
       selectedIndex: aq.selectedIndex,
-      isCorrect: aq.isCorrect,
+      isCorrect: isCompleted ? aq.isCorrect : null,
       question: {
         id: aq.question.id,
         category: aq.question.category,
         level: aq.question.level,
         questionText: aq.question.questionText,
         choices: aq.question.choices,
-        answerIndex: aq.question.answerIndex,
-        explanation: aq.question.explanation,
+        ...(isCompleted
+          ? {
+              answerIndex: aq.question.answerIndex,
+              explanation: aq.question.explanation,
+            }
+          : {}),
       },
     }));
 

--- a/app/me/me-dashboard.tsx
+++ b/app/me/me-dashboard.tsx
@@ -39,8 +39,8 @@ type QuestionDetail = {
     level: number;
     questionText: string;
     choices: string[];
-    answerIndex: number;
-    explanation: string;
+    answerIndex?: number;
+    explanation?: string;
   };
 };
 
@@ -1222,10 +1222,12 @@ const AttemptDetailView = ({ attempt }: { attempt: AttemptDetail }) => {
                 })}
               </div>
 
-              <div className="rounded-lg bg-neutral-50 px-3 py-2 text-sm text-neutral-600 dark:bg-neutral-800/50 dark:text-neutral-400">
-                <span className="font-medium">解説: </span>
-                {q.question.explanation}
-              </div>
+              {q.question.explanation && (
+                <div className="rounded-lg bg-neutral-50 px-3 py-2 text-sm text-neutral-600 dark:bg-neutral-800/50 dark:text-neutral-400">
+                  <span className="font-medium">解説: </span>
+                  {q.question.explanation}
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/app/quiz/[attemptId]/quiz-runner.tsx
+++ b/app/quiz/[attemptId]/quiz-runner.tsx
@@ -124,7 +124,6 @@ export const QuizRunner = ({ attemptId }: Props) => {
       const result = (await response.json()) as {
         attemptQuestionId: string;
         selectedIndex: number;
-        isCorrect: boolean;
       };
 
       setAttempt((prev) => {
@@ -135,7 +134,6 @@ export const QuizRunner = ({ attemptId }: Props) => {
             ? {
                 ...q,
                 selectedIndex: result.selectedIndex,
-                isCorrect: result.isCorrect,
               }
             : q,
         );

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -115,7 +115,7 @@ paths:
   /api/attempts/{attemptId}/answer:
     post:
       tags: [Attempts]
-      summary: 回答保存
+      summary: 回答保存（1問につき1回のみ）
       security:
         - cookieAuth: []
       parameters:
@@ -503,11 +503,12 @@ components:
 
     AnswerAttemptResponse:
       type: object
-      required: [message]
+      required: [attemptQuestionId, selectedIndex]
       properties:
-        message:
+        attemptQuestionId:
           type: string
-          example: saved
+        selectedIndex:
+          type: integer
 
     CategoryBreakdownItem:
       type: object
@@ -565,12 +566,13 @@ components:
         isCorrect:
           type: boolean
           nullable: true
+          description: COMPLETED時のみ非null（IN_PROGRESS中はnull）
         answerIndex:
           type: integer
-          description: finalize後のみ返却
+          description: COMPLETED時のみ返却
         explanation:
           type: string
-          description: finalize後のみ返却
+          description: COMPLETED時のみ返却
         category:
           type: string
 


### PR DESCRIPTION
## Summary

- `GET /api/me/attempts/[attemptId]` で `COMPLETED` 時のみ `answerIndex` / `explanation` を返却するよう修正（IN_PROGRESS中の正解漏洩を防止）
- `POST /api/attempts/[attemptId]/answer` からレスポンスの `isCorrect` を除外（finalize後にのみ正誤を開示）
- 同APIに既回答済みチェックを追加し、再回答を拒否（400エラー）
- フロントエンド（`quiz-runner.tsx` / `me-dashboard.tsx`）の型定義と利用箇所を調整
- OpenAPIスペックを実装に合わせて更新

## 変更内容

### バックエンド
| ファイル | 変更 |
|---|---|
| `app/api/me/attempts/[attemptId]/route.ts` | `isCompleted` 条件分岐を追加。IN_PROGRESS中は `answerIndex` / `explanation` / `isCorrect` を非公開に |
| `app/api/attempts/[attemptId]/answer/route.ts` | レスポンスから `isCorrect` を除外。`selectedIndex !== null` の既回答ガードを追加 |

### フロントエンド
| ファイル | 変更 |
|---|---|
| `app/quiz/[attemptId]/quiz-runner.tsx` | 回答APIレスポンスの型から `isCorrect` を削除。状態更新を `selectedIndex` のみに変更 |
| `app/me/me-dashboard.tsx` | `QuestionDetail.question` の `answerIndex` / `explanation` をoptionalに変更。解説表示に条件チェックを追加 |

### ドキュメント
| ファイル | 変更 |
|---|---|
| `docs/openapi.yaml` | `AnswerAttemptResponse` を実態に合わせて更新。`AttemptQuestionItem` のフィールド説明を更新 |

## 動作確認手順

1. テストを開始し、IN_PROGRESS中にDevToolsで `GET /api/me/attempts/{attemptId}` を確認 → `answerIndex` / `explanation` が含まれないこと
2. 回答を送信 → レスポンスに `isCorrect` が含まれないこと
3. 同じ問題に再度回答を試みる → 400エラーが返ること
4. 全問回答後に採点 → 結果画面で正解・解説が正しく表示されること
5. マイページで過去の受験結果を確認 → 不正解問題の解説が正しく表示されること

closes #96

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented re-answering questions; each question can now only be answered once.

* **Documentation**
  * Updated API documentation for answer submissions, including new response structure and clarified visibility rules for quiz results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->