### PR TITLE
fix(security): signupのレート制限と列挙耐性を強化

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -89,8 +89,10 @@ const LoginPage = () => {
       if (!response.ok) {
         const data = (await response.json()) as { message?: string };
 
-        if (response.status === 409) {
-          setErrors({ form: "このメールアドレスは既に登録されています" });
+        if (mode === "signup" && response.status === 400) {
+          setErrors({
+            form: "アカウント作成に失敗しました。入力内容をご確認ください",
+          });
         } else if (response.status === 401) {
           setErrors({ form: "メールアドレスまたはパスワードが正しくありません" });
         } else if (response.status === 429) {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -28,8 +28,13 @@ paths:
                 $ref: "#/components/schemas/AuthSuccessResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
-        "409":
-          description: メール重複
+        "429":
+          description: 試行回数超過（レート制限）
+          headers:
+            Retry-After:
+              description: 次回試行までの待機秒数
+              schema:
+                type: integer
           content:
             application/json:
               schema:

--- a/lib/auth/signup-rate-limit.ts
+++ b/lib/auth/signup-rate-limit.ts
@@ -1,0 +1,150 @@
+type SignupRateLimitRecord = {
+  attempts: number;
+  windowStartedAt: number;
+  blockedUntil: number | null;
+};
+
+type SignupRateLimitResult = {
+  allowed: boolean;
+  retryAfterSeconds: number;
+};
+
+const DEFAULT_MAX_ATTEMPTS = 10;
+const DEFAULT_WINDOW_SECONDS = 300;
+const DEFAULT_BLOCK_SECONDS = 900;
+
+const signupRateLimitStore = new Map<string, SignupRateLimitRecord>();
+
+const parsePositiveInt = (value: string | undefined, fallback: number): number => {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return parsed;
+};
+
+const getMaxAttempts = (): number => {
+  return parsePositiveInt(
+    process.env["SIGNUP_RATE_LIMIT_MAX_ATTEMPTS"],
+    DEFAULT_MAX_ATTEMPTS,
+  );
+};
+
+const getWindowMs = (): number => {
+  const seconds = parsePositiveInt(
+    process.env["SIGNUP_RATE_LIMIT_WINDOW_SECONDS"],
+    DEFAULT_WINDOW_SECONDS,
+  );
+  return seconds * 1000;
+};
+
+const getBlockMs = (): number => {
+  const seconds = parsePositiveInt(
+    process.env["SIGNUP_RATE_LIMIT_BLOCK_SECONDS"],
+    DEFAULT_BLOCK_SECONDS,
+  );
+  return seconds * 1000;
+};
+
+const normalizeIpAddress = (request: Request): string => {
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const firstIp = forwardedFor.split(",")[0]?.trim();
+    if (firstIp) {
+      return firstIp;
+    }
+  }
+
+  const realIp = request.headers.get("x-real-ip")?.trim();
+  if (realIp) {
+    return realIp;
+  }
+
+  return "unknown";
+};
+
+const cleanupExpiredRecords = (now: number): void => {
+  const ttl = Math.max(getWindowMs(), getBlockMs());
+
+  for (const [key, record] of signupRateLimitStore.entries()) {
+    const blockedExpired =
+      record.blockedUntil === null || record.blockedUntil <= now;
+    const windowExpired = now - record.windowStartedAt > ttl;
+
+    if (blockedExpired && windowExpired) {
+      signupRateLimitStore.delete(key);
+    }
+  }
+};
+
+export const getSignupRateLimitKey = (request: Request): string => {
+  return normalizeIpAddress(request);
+};
+
+export const checkSignupRateLimit = (key: string): SignupRateLimitResult => {
+  const now = Date.now();
+  const record = signupRateLimitStore.get(key);
+
+  if (!record) {
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  if (record.blockedUntil !== null && record.blockedUntil > now) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.ceil((record.blockedUntil - now) / 1000),
+    };
+  }
+
+  if (record.blockedUntil !== null && record.blockedUntil <= now) {
+    signupRateLimitStore.delete(key);
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  return { allowed: true, retryAfterSeconds: 0 };
+};
+
+export const registerSignupAttempt = (key: string): SignupRateLimitResult => {
+  const now = Date.now();
+  cleanupExpiredRecords(now);
+
+  const existing = signupRateLimitStore.get(key);
+  const windowMs = getWindowMs();
+  const maxAttempts = getMaxAttempts();
+  const blockMs = getBlockMs();
+
+  if (!existing || now - existing.windowStartedAt > windowMs) {
+    signupRateLimitStore.set(key, {
+      attempts: 1,
+      windowStartedAt: now,
+      blockedUntil: null,
+    });
+    return { allowed: true, retryAfterSeconds: 0 };
+  }
+
+  const attempts = existing.attempts + 1;
+  if (attempts >= maxAttempts) {
+    const blockedUntil = now + blockMs;
+    signupRateLimitStore.set(key, {
+      attempts,
+      windowStartedAt: existing.windowStartedAt,
+      blockedUntil,
+    });
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.ceil(blockMs / 1000),
+    };
+  }
+
+  signupRateLimitStore.set(key, {
+    attempts,
+    windowStartedAt: existing.windowStartedAt,
+    blockedUntil: null,
+  });
+  return { allowed: true, retryAfterSeconds: 0 };
+};


### PR DESCRIPTION
## Summary

- `POST /api/auth/signup` にIPベースのレート制限を追加（429 + `Retry-After`）
- サインアップ失敗時の重複メール専用メッセージを廃止し、汎用メッセージに変更
- ログイン/サインアップ画面のエラーハンドリングを新仕様に追従
- OpenAPI の `/api/auth/signup` レスポンス定義を更新（409削除、429追加）

## 変更ファイル

- `lib/auth/signup-rate-limit.ts`（新規）
- `app/api/auth/signup/route.ts`
- `app/login/page.tsx`
- `docs/openapi.yaml`

## Test plan

- `npm run lint`
- `npm run build`
- signup APIを短時間で連続実行し、429と`Retry-After`を確認
- 既存メールでsignupした際に専用エラーメッセージが返らないことを確認

closes #98

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate-limiting to signup attempts to prevent abuse; users exceeding the limit receive a response with retry-after guidance.

* **Bug Fixes**
  * Updated signup error handling for duplicate emails; error messages and response codes now more accurately reflect the failure reason.

* **Documentation**
  * Updated API documentation to reflect rate-limiting responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->