### PR TITLE
fix(security): AUTH_SECRETの最小長チェックを追加

### DIFF
--- a/lib/auth/config.ts
+++ b/lib/auth/config.ts
@@ -1,8 +1,16 @@
+const MIN_AUTH_SECRET_LENGTH = 32;
+
 export const getAuthSecret = (): string => {
   const authSecret = process.env["AUTH_SECRET"];
 
   if (!authSecret) {
     throw new Error("AUTH_SECRET is not set");
+  }
+
+  if (authSecret.length < MIN_AUTH_SECRET_LENGTH) {
+    throw new Error(
+      `AUTH_SECRET must be at least ${MIN_AUTH_SECRET_LENGTH} characters long`,
+    );
   }
 
   return authSecret;


### PR DESCRIPTION
## Summary

- `lib/auth/config.ts` に `AUTH_SECRET` の最小長チェック（32文字）を追加
- 未設定だけでなく、短すぎるシークレットも起動時に明示的にエラーにする

## Changes

- `MIN_AUTH_SECRET_LENGTH = 32` を定義
- `getAuthSecret()` で `authSecret.length < 32` の場合に例外を投げる

## Test plan

- `npm run lint`
- `npm run build`

closes #99

Made with [Cursor](https://cursor.com)