### PR TITLE
fix(security): 入力バリデーション強化とパスパラメータ検証を追加

### DIFF
--- a/app/api/attempts/[attemptId]/route.ts
+++ b/app/api/attempts/[attemptId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { attemptParamsSchema } from "@/lib/attempt/schemas";
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
@@ -19,7 +20,15 @@ export const GET = async (
       return messageResponse("unauthorized", 401);
     }
 
-    const { attemptId } = await context.params;
+    const params = await context.params;
+    const parsedParams = attemptParamsSchema.safeParse(params);
+    if (!parsedParams.success) {
+      return messageResponse(
+        parsedParams.error.issues[0]?.message ?? "invalid attemptId",
+        400,
+      );
+    }
+    const { attemptId } = parsedParams.data;
 
     const attempt = await prisma.attempt.findUnique({
       where: { id: attemptId },

--- a/app/api/attempts/create/route.ts
+++ b/app/api/attempts/create/route.ts
@@ -8,8 +8,9 @@ import { prisma } from "@/lib/db/prisma";
 
 const createAttemptSchema = z.object({
   categories: z
-    .array(z.string().min(1))
-    .min(1, "カテゴリを1つ以上選択してください"),
+    .array(z.string().min(1).max(200, "カテゴリ名が長すぎます"))
+    .min(1, "カテゴリを1つ以上選択してください")
+    .max(100, "カテゴリ数が多すぎます"),
   level: z.number().int().min(1).max(3),
   count: z.number().int().min(1).max(50),
 });

--- a/app/api/me/attempts/[attemptId]/export/route.ts
+++ b/app/api/me/attempts/[attemptId]/export/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { attemptParamsSchema } from "@/lib/attempt/schemas";
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
 import {
@@ -28,7 +29,15 @@ export const GET = async (
       return messageResponse("unauthorized", 401);
     }
 
-    const { attemptId } = await context.params;
+    const params = await context.params;
+    const parsedParams = attemptParamsSchema.safeParse(params);
+    if (!parsedParams.success) {
+      return messageResponse(
+        parsedParams.error.issues[0]?.message ?? "invalid attemptId",
+        400,
+      );
+    }
+    const { attemptId } = parsedParams.data;
     const { searchParams } = new URL(request.url);
     const formatParam = searchParams.get("format");
 

--- a/app/api/me/attempts/[attemptId]/route.ts
+++ b/app/api/me/attempts/[attemptId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { attemptParamsSchema } from "@/lib/attempt/schemas";
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
@@ -19,7 +20,15 @@ export const GET = async (
       return messageResponse("unauthorized", 401);
     }
 
-    const { attemptId } = await context.params;
+    const params = await context.params;
+    const parsedParams = attemptParamsSchema.safeParse(params);
+    if (!parsedParams.success) {
+      return messageResponse(
+        parsedParams.error.issues[0]?.message ?? "invalid attemptId",
+        400,
+      );
+    }
+    const { attemptId } = parsedParams.data;
 
     const attempt = await prisma.attempt.findUnique({
       where: { id: attemptId },

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -450,9 +450,11 @@ components:
         email:
           type: string
           format: email
+          maxLength: 254
         password:
           type: string
           minLength: 8
+          maxLength: 128
           description: 英大文字・英小文字・数字を各1文字以上含む
 
     LoginRequest:
@@ -462,8 +464,11 @@ components:
         email:
           type: string
           format: email
+          maxLength: 254
         password:
           type: string
+          minLength: 1
+          maxLength: 128
 
     AuthSuccessResponse:
       type: object
@@ -481,7 +486,9 @@ components:
           type: array
           items:
             type: string
+            maxLength: 200
           minItems: 1
+          maxItems: 100
         level:
           type: integer
           enum: [1, 2, 3]
@@ -502,9 +509,12 @@ components:
       properties:
         attemptQuestionId:
           type: string
+          minLength: 1
+          maxLength: 100
         selectedIndex:
           type: integer
           minimum: 0
+          maximum: 3
 
     AnswerAttemptResponse:
       type: object

--- a/lib/attempt/schemas.ts
+++ b/lib/attempt/schemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const attemptIdSchema = z
+  .string()
+  .min(1, "attemptId is required")
+  .max(100, "attemptId is too long");
+
+export const attemptParamsSchema = z.object({
+  attemptId: attemptIdSchema,
+});

--- a/lib/auth/schemas.ts
+++ b/lib/auth/schemas.ts
@@ -1,25 +1,48 @@
 import { z } from "zod";
 import { getPasswordPolicyErrorMessage } from "@/lib/auth/password-policy";
 
-const emailSchema = z.email().trim().toLowerCase();
+const MAX_EMAIL_LENGTH = 254;
+const MAX_PASSWORD_LENGTH = 128;
+
+const emailSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .email("有効なメールアドレスを入力してください")
+  .max(
+    MAX_EMAIL_LENGTH,
+    `メールアドレスは${MAX_EMAIL_LENGTH}文字以内で入力してください`,
+  );
 
 export const signupInputSchema = z.object({
   email: emailSchema,
-  password: z.string().superRefine((value, context) => {
-    const errorMessage = getPasswordPolicyErrorMessage(value);
+  password: z
+    .string()
+    .max(
+      MAX_PASSWORD_LENGTH,
+      `パスワードは${MAX_PASSWORD_LENGTH}文字以内で入力してください`,
+    )
+    .superRefine((value, context) => {
+      const errorMessage = getPasswordPolicyErrorMessage(value);
 
-    if (errorMessage) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: errorMessage,
-      });
-    }
-  }),
+      if (errorMessage) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: errorMessage,
+        });
+      }
+    }),
 });
 
 export const loginInputSchema = z.object({
   email: emailSchema,
-  password: z.string().min(1, "パスワードを入力してください"),
+  password: z
+    .string()
+    .min(1, "パスワードを入力してください")
+    .max(
+      MAX_PASSWORD_LENGTH,
+      `パスワードは${MAX_PASSWORD_LENGTH}文字以内で入力してください`,
+    ),
 });
 
 export const authInputSchema = signupInputSchema;


### PR DESCRIPTION
## Summary

- `lib/auth/schemas.ts` に入力上限を追加
  - email: max 254
  - password: max 128（signup/login）
- `POST /api/attempts/create` の `categories` を強化
  - 各カテゴリ名: max 200
  - 配列件数: max 100
- `POST /api/attempts/{attemptId}/answer` の `attemptQuestionId` に max 100 を追加
- `attemptId` パスパラメータ検証を共通化
  - `lib/attempt/schemas.ts` を追加
  - `app/api/attempts/[attemptId]/route.ts`
  - `app/api/attempts/[attemptId]/answer/route.ts`
  - `app/api/me/attempts/[attemptId]/route.ts`
  - `app/api/me/attempts/[attemptId]/export/route.ts`
- `docs/openapi.yaml` に maxLength/maxItems 等の制約を反映

## Test plan

- `npm run lint`
- `npm run build`

closes #100

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced maximum length limits on email, password, category names, and question identifiers across API endpoints to prevent processing of oversized inputs.
  * Enhanced error handling with clearer validation messages, enabling users to quickly identify and correct invalid submissions.

* **Documentation**
  * Updated API specifications to document new input constraints and validation requirements across signup, login, and attempt-related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->