### PR TITLE
refactor(app): attempt系スキーマ定義を集約して重複排除

### DIFF
--- a/app/api/attempts/[attemptId]/answer/route.ts
+++ b/app/api/attempts/[attemptId]/answer/route.ts
@@ -1,16 +1,10 @@
 import { NextResponse } from "next/server";
-import { z } from "zod";
 
-import { attemptParamsSchema } from "@/lib/attempt/schemas";
+import { answerSchema, attemptParamsSchema } from "@/lib/attempt/schemas";
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { isValidOrigin, isJsonContentType } from "@/lib/auth/origin";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
-
-const answerSchema = z.object({
-  attemptQuestionId: z.string().min(1).max(100, "attemptQuestionId is too long"),
-  selectedIndex: z.number().int().min(0).max(3),
-});
 
 type RouteContext = {
   params: Promise<{ attemptId: string }>;

--- a/app/api/attempts/create/route.ts
+++ b/app/api/attempts/create/route.ts
@@ -1,19 +1,10 @@
 import { NextResponse } from "next/server";
-import { z } from "zod";
 
+import { createAttemptSchema } from "@/lib/attempt/schemas";
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { isValidOrigin, isJsonContentType } from "@/lib/auth/origin";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
-
-const createAttemptSchema = z.object({
-  categories: z
-    .array(z.string().min(1).max(200, "カテゴリ名が長すぎます"))
-    .min(1, "カテゴリを1つ以上選択してください")
-    .max(100, "カテゴリ数が多すぎます"),
-  level: z.number().int().min(1).max(3),
-  count: z.number().int().min(1).max(50),
-});
 
 const shuffleInPlace = <T>(items: T[]): T[] => {
   const shuffled = [...items];

--- a/app/api/me/attempts/[attemptId]/deliver-notion/route.ts
+++ b/app/api/me/attempts/[attemptId]/deliver-notion/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { NotionDeliveryJobStatus, Prisma } from "@prisma/client";
-import { z } from "zod";
 
+import { attemptParamsSchema } from "@/lib/attempt/schemas";
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
 import { isValidOrigin } from "@/lib/auth/origin";
@@ -15,10 +15,6 @@ import { runNotionDeliveryJob } from "@/lib/notion/job";
 type RouteContext = {
   params: Promise<{ attemptId: string }>;
 };
-
-const attemptParamsSchema = z.object({
-  attemptId: z.string().min(1),
-});
 
 const ACTIVE_NOTION_JOB_STATUSES: NotionDeliveryJobStatus[] = [
   NotionDeliveryJobStatus.QUEUED,

--- a/app/api/me/attempts/route.ts
+++ b/app/api/me/attempts/route.ts
@@ -1,27 +1,12 @@
 import { NextResponse } from "next/server";
-import { z } from "zod";
 
+import {
+  attemptsQuerySchema,
+  DEFAULT_ATTEMPTS_PAGE_SIZE,
+} from "@/lib/attempt/schemas";
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
-
-const DEFAULT_PAGE_SIZE = 10;
-const MAX_PAGE_SIZE = 50;
-
-const attemptsQuerySchema = z.object({
-  page: z
-    .string()
-    .regex(/^\d+$/)
-    .transform(Number)
-    .refine((value) => value >= 1)
-    .optional(),
-  pageSize: z
-    .string()
-    .regex(/^\d+$/)
-    .transform(Number)
-    .refine((value) => value >= 1 && value <= MAX_PAGE_SIZE)
-    .optional(),
-});
 
 type AttemptWithResult = {
   id: string;
@@ -66,7 +51,7 @@ export const GET = async (request: Request): Promise<NextResponse> => {
       return messageResponse("invalid query parameters", 400);
     }
     const requestedPage = queryResult.data.page ?? 1;
-    const pageSize = queryResult.data.pageSize ?? DEFAULT_PAGE_SIZE;
+    const pageSize = queryResult.data.pageSize ?? DEFAULT_ATTEMPTS_PAGE_SIZE;
 
     const [totalCount, latestCompleted, latestInProgress] = await Promise.all([
       prisma.attempt.count({

--- a/lib/attempt/schemas.ts
+++ b/lib/attempt/schemas.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const DEFAULT_ATTEMPTS_PAGE_SIZE = 10;
+export const MAX_ATTEMPTS_PAGE_SIZE = 50;
+
 export const attemptIdSchema = z
   .string()
   .min(1, "attemptId is required")
@@ -7,4 +10,33 @@ export const attemptIdSchema = z
 
 export const attemptParamsSchema = z.object({
   attemptId: attemptIdSchema,
+});
+
+export const createAttemptSchema = z.object({
+  categories: z
+    .array(z.string().min(1).max(200, "カテゴリ名が長すぎます"))
+    .min(1, "カテゴリを1つ以上選択してください")
+    .max(100, "カテゴリ数が多すぎます"),
+  level: z.number().int().min(1).max(3),
+  count: z.number().int().min(1).max(50),
+});
+
+export const answerSchema = z.object({
+  attemptQuestionId: z.string().min(1).max(100, "attemptQuestionId is too long"),
+  selectedIndex: z.number().int().min(0).max(3),
+});
+
+export const attemptsQuerySchema = z.object({
+  page: z
+    .string()
+    .regex(/^\d+$/)
+    .transform(Number)
+    .refine((value) => value >= 1)
+    .optional(),
+  pageSize: z
+    .string()
+    .regex(/^\d+$/)
+    .transform(Number)
+    .refine((value) => value >= 1 && value <= MAX_ATTEMPTS_PAGE_SIZE)
+    .optional(),
 });


### PR DESCRIPTION
## Summary

- `lib/attempt/schemas.ts` に attempt関連スキーマを集約
  - `createAttemptSchema`
  - `answerSchema`
  - `attemptsQuerySchema`
  - `attemptParamsSchema`
- Route Handler 側のローカルスキーマ定義を削除し、共通スキーマ参照へ統一
- `deliver-notion` ルート内の `attemptParamsSchema` 重複定義を解消

## 対象ファイル

- `lib/attempt/schemas.ts`
- `app/api/attempts/create/route.ts`
- `app/api/attempts/[attemptId]/answer/route.ts`
- `app/api/me/attempts/route.ts`
- `app/api/me/attempts/[attemptId]/deliver-notion/route.ts`

## Test plan

- `npm run lint`
- `npm run build`

closes #112

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated validation schemas into a centralized location for improved maintainability across API endpoints.
  
* **Bug Fixes**
  * Updated attempt ID validation to enforce maximum length constraint, preventing excessively long identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->