### PR TITLE
refactor(api): API Route Handler の共通ガード処理を抽出

### DIFF
--- a/app/api/attempts/[attemptId]/answer/route.ts
+++ b/app/api/attempts/[attemptId]/answer/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from "next/server";
 
 import { answerSchema, attemptParamsSchema } from "@/lib/attempt/schemas";
-import { getUserFromRequest } from "@/lib/auth/guards";
-import { isValidOrigin, isJsonContentType } from "@/lib/auth/origin";
+import {
+  requireAuthenticatedUser,
+  requireJsonContentType,
+  requireValidOrigin,
+} from "@/lib/api/guards";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
 
@@ -15,18 +18,20 @@ export const POST = async (
   context: RouteContext,
 ): Promise<NextResponse> => {
   try {
-    if (!isValidOrigin(request)) {
-      return messageResponse("invalid origin", 403);
+    const invalidOriginResponse = requireValidOrigin(request);
+    if (invalidOriginResponse) {
+      return invalidOriginResponse;
     }
 
-    if (!isJsonContentType(request)) {
-      return messageResponse("content-type must be application/json", 415);
+    const invalidContentTypeResponse = requireJsonContentType(request);
+    if (invalidContentTypeResponse) {
+      return invalidContentTypeResponse;
     }
 
-    const user = await getUserFromRequest(request);
-
-    if (!user) {
-      return messageResponse("unauthorized", 401);
+    const { user, response: unauthorizedResponse } =
+      await requireAuthenticatedUser(request);
+    if (unauthorizedResponse || !user) {
+      return unauthorizedResponse ?? messageResponse("unauthorized", 401);
     }
 
     const params = await context.params;

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
 
+import {
+  requireJsonContentType,
+  requireValidOrigin,
+} from "@/lib/api/guards";
 import { setSessionCookie } from "@/lib/auth/cookie";
 import { getAuthSecret } from "@/lib/auth/config";
 import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
@@ -9,19 +13,20 @@ import {
   getLoginRateLimitKey,
   registerFailedLoginAttempt,
 } from "@/lib/auth/login-rate-limit";
-import { isValidOrigin, isJsonContentType } from "@/lib/auth/origin";
 import { verifyPassword } from "@/lib/auth/password";
 import { loginInputSchema } from "@/lib/auth/schemas";
 import { createSessionToken } from "@/lib/auth/session-token";
 import { prisma } from "@/lib/db/prisma";
 
 export const POST = async (request: Request): Promise<NextResponse> => {
-  if (!isValidOrigin(request)) {
-    return messageResponse("forbidden origin", 403);
+  const invalidOriginResponse = requireValidOrigin(request, "forbidden origin");
+  if (invalidOriginResponse) {
+    return invalidOriginResponse;
   }
 
-  if (!isJsonContentType(request)) {
-    return messageResponse("content-type must be application/json", 415);
+  const invalidContentTypeResponse = requireJsonContentType(request);
+  if (invalidContentTypeResponse) {
+    return invalidContentTypeResponse;
   }
 
   try {

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 
+import { requireJsonContentType, requireValidOrigin } from "@/lib/api/guards";
 import { setSessionCookie } from "@/lib/auth/cookie";
 import { getAuthSecret } from "@/lib/auth/config";
 import { internalServerErrorResponse, messageResponse } from "@/lib/auth/http";
-import { isValidOrigin, isJsonContentType } from "@/lib/auth/origin";
 import { hashPassword } from "@/lib/auth/password";
 import {
   checkSignupRateLimit,
@@ -16,12 +16,14 @@ import { createSessionToken } from "@/lib/auth/session-token";
 import { prisma } from "@/lib/db/prisma";
 
 export const POST = async (request: Request): Promise<NextResponse> => {
-  if (!isValidOrigin(request)) {
-    return messageResponse("forbidden origin", 403);
+  const invalidOriginResponse = requireValidOrigin(request, "forbidden origin");
+  if (invalidOriginResponse) {
+    return invalidOriginResponse;
   }
 
-  if (!isJsonContentType(request)) {
-    return messageResponse("content-type must be application/json", 415);
+  const invalidContentTypeResponse = requireJsonContentType(request);
+  if (invalidContentTypeResponse) {
+    return invalidContentTypeResponse;
   }
 
   try {

--- a/lib/api/guards.ts
+++ b/lib/api/guards.ts
@@ -1,0 +1,38 @@
+import { type NextResponse } from "next/server";
+
+import { getUserFromRequest, type AuthUser } from "@/lib/auth/guards";
+import { messageResponse } from "@/lib/auth/http";
+import { isJsonContentType, isValidOrigin } from "@/lib/auth/origin";
+
+export const requireValidOrigin = (
+  request: Request,
+  message = "invalid origin",
+): NextResponse | null => {
+  if (!isValidOrigin(request)) {
+    return messageResponse(message, 403);
+  }
+
+  return null;
+};
+
+export const requireJsonContentType = (
+  request: Request,
+): NextResponse | null => {
+  if (!isJsonContentType(request)) {
+    return messageResponse("content-type must be application/json", 415);
+  }
+
+  return null;
+};
+
+export const requireAuthenticatedUser = async (
+  request: Request,
+): Promise<{ user: AuthUser | null; response: NextResponse | null }> => {
+  const user = await getUserFromRequest(request);
+
+  if (!user) {
+    return { user: null, response: messageResponse("unauthorized", 401) };
+  }
+
+  return { user, response: null };
+};


### PR DESCRIPTION
## Summary

- `lib/api/guards.ts` を追加し、Route Handlerの共通前処理を集約
  - `requireValidOrigin`
  - `requireJsonContentType`
  - `requireAuthenticatedUser`
- 以下のルートで共通ガードを適用
  - `app/api/auth/login/route.ts`
  - `app/api/auth/signup/route.ts`
  - `app/api/auth/logout/route.ts`
  - `app/api/attempts/create/route.ts`
  - `app/api/attempts/[attemptId]/answer/route.ts`
  - `app/api/attempts/[attemptId]/finalize/route.ts`
  - `app/api/me/attempts/[attemptId]/deliver-notion/route.ts`
- `finalize` routeで `attemptId` のパラメータ検証を追加（既存方針に整合）

## Test plan

- `npm run lint`
- `npm run build`

closes #110

Made with [Cursor](https://cursor.com)