### PR TITLE
feat(app): / を認証状態に応じて /login・/select へリダイレクト

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,40 +1,10 @@
-const Home = () => {
-  return (
-    <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
-      <h1 className="text-2xl font-bold">AWS理解度テスト MVP</h1>
-      <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-300">
-        このIssueでは、Next.js + Tailwind + Prisma + PostgreSQL(docker-compose)
-        の初期構築を行っています。
-      </p>
+import { redirect } from "next/navigation";
 
-      <ul className="mt-6 grid gap-3 text-sm sm:grid-cols-2">
-        <li className="rounded-xl border border-black/10 p-4 dark:border-white/15">
-          <p className="font-semibold">/login</p>
-          <p className="mt-1 text-neutral-600 dark:text-neutral-300">
-            ログイン/サインアップ画面（次Issueで実装）
-          </p>
-        </li>
-        <li className="rounded-xl border border-black/10 p-4 dark:border-white/15">
-          <p className="font-semibold">/select</p>
-          <p className="mt-1 text-neutral-600 dark:text-neutral-300">
-            問題条件を選択して受験開始（次Issueで実装）
-          </p>
-        </li>
-        <li className="rounded-xl border border-black/10 p-4 dark:border-white/15">
-          <p className="font-semibold">/quiz/[attemptId]</p>
-          <p className="mt-1 text-neutral-600 dark:text-neutral-300">
-            1問ずつ回答するクイズ画面（次Issueで実装）
-          </p>
-        </li>
-        <li className="rounded-xl border border-black/10 p-4 dark:border-white/15">
-          <p className="font-semibold">/me</p>
-          <p className="mt-1 text-neutral-600 dark:text-neutral-300">
-            受験履歴とカテゴリ別スコア表示（次Issueで実装）
-          </p>
-        </li>
-      </ul>
-    </section>
-  );
+import { getCurrentUser } from "@/lib/auth/guards";
+
+const Home = async () => {
+  const user = await getCurrentUser();
+  redirect(user ? "/select" : "/login");
 };
 
 export default Home;


### PR DESCRIPTION
## Summary

- `app/page.tsx` の初期案内ページを廃止
- `/` で `getCurrentUser()` により認証状態を判定
- 未ログイン時は `/login`、ログイン済みは `/select` へリダイレクト

## Why

- 初期構築時の案内文が残っており、実運用導線として不要なため
- ユーザーを即時に適切な導線へ案内するため

## Test plan

- `npm run lint`
- `npm run build`
- 未ログイン状態で `/` アクセス -> `/login` へ遷移
- ログイン済み状態で `/` アクセス -> `/select` へ遷移

closes #117

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Home page now implements authentication-based redirection. Authenticated users are directed to the selection page, while non-authenticated users are directed to the login page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->