### PR TITLE
refactor(app): CategoryScore共通化とJson境界の型安全性強化

### DIFF
--- a/app/api/attempts/[attemptId]/route.ts
+++ b/app/api/attempts/[attemptId]/route.ts
@@ -4,6 +4,7 @@ import { attemptParamsSchema } from "@/lib/attempt/schemas";
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
+import { parseCategoryBreakdown, parseQuestionChoices } from "@/lib/quiz/parsers";
 
 type RouteContext = {
   params: Promise<{ attemptId: string }>;
@@ -72,7 +73,7 @@ export const GET = async (
         category: aq.question.category,
         level: aq.question.level,
         questionText: aq.question.questionText,
-        choices: aq.question.choices,
+        choices: parseQuestionChoices(aq.question.choices),
         ...(attempt.status === "COMPLETED"
           ? {
               answerIndex: aq.question.answerIndex,
@@ -92,7 +93,9 @@ export const GET = async (
       result: attempt.result
         ? {
             overallPercent: attempt.result.overallPercent,
-            categoryBreakdown: attempt.result.categoryBreakdown,
+            categoryBreakdown: parseCategoryBreakdown(
+              attempt.result.categoryBreakdown,
+            ),
           }
         : null,
     });

--- a/app/api/me/attempts/[attemptId]/export/route.ts
+++ b/app/api/me/attempts/[attemptId]/export/route.ts
@@ -8,6 +8,7 @@ import {
   createAttemptExportPayload,
 } from "@/lib/attempt/export";
 import { prisma } from "@/lib/db/prisma";
+import { parseCategoryBreakdown, parseQuestionChoices } from "@/lib/quiz/parsers";
 
 type RouteContext = {
   params: Promise<{ attemptId: string }>;
@@ -91,19 +92,16 @@ export const GET = async (
       },
       result: {
         overallPercent: attempt.result.overallPercent,
-        categoryBreakdown: attempt.result.categoryBreakdown as {
-          category: string;
-          total: number;
-          correct: number;
-          percent: number;
-        }[],
+        categoryBreakdown: parseCategoryBreakdown(
+          attempt.result.categoryBreakdown,
+        ),
       },
       questions: attempt.questions.map((question) => ({
         order: question.order,
         category: question.question.category,
         level: question.question.level,
         questionText: question.question.questionText,
-        choices: question.question.choices as string[],
+        choices: parseQuestionChoices(question.question.choices),
         answerIndex: question.question.answerIndex,
         selectedIndex: question.selectedIndex,
         isCorrect: question.isCorrect,

--- a/app/api/me/attempts/[attemptId]/route.ts
+++ b/app/api/me/attempts/[attemptId]/route.ts
@@ -4,6 +4,7 @@ import { attemptParamsSchema } from "@/lib/attempt/schemas";
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
+import { parseCategoryBreakdown, parseQuestionChoices } from "@/lib/quiz/parsers";
 
 type RouteContext = {
   params: Promise<{ attemptId: string }>;
@@ -73,7 +74,7 @@ export const GET = async (
         category: aq.question.category,
         level: aq.question.level,
         questionText: aq.question.questionText,
-        choices: aq.question.choices,
+        choices: parseQuestionChoices(aq.question.choices),
         ...(isCompleted
           ? {
               answerIndex: aq.question.answerIndex,
@@ -93,7 +94,9 @@ export const GET = async (
       result: attempt.result
         ? {
             overallPercent: attempt.result.overallPercent,
-            categoryBreakdown: attempt.result.categoryBreakdown,
+            categoryBreakdown: parseCategoryBreakdown(
+              attempt.result.categoryBreakdown,
+            ),
           }
         : null,
     });

--- a/app/api/me/attempts/route.ts
+++ b/app/api/me/attempts/route.ts
@@ -7,8 +7,9 @@ import {
 import { getUserFromRequest } from "@/lib/auth/guards";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
+import { parseCategoryBreakdown } from "@/lib/quiz/parsers";
 
-type AttemptWithResult = {
+type AttemptSummarySource = {
   id: string;
   status: "IN_PROGRESS" | "COMPLETED";
   filters: unknown;
@@ -20,7 +21,7 @@ type AttemptWithResult = {
   } | null;
 };
 
-const toAttemptSummary = (attempt: AttemptWithResult) => ({
+const toAttemptSummary = (attempt: AttemptSummarySource) => ({
   id: attempt.id,
   status: attempt.status,
   filters: attempt.filters,
@@ -29,7 +30,9 @@ const toAttemptSummary = (attempt: AttemptWithResult) => ({
   result: attempt.result
     ? {
         overallPercent: attempt.result.overallPercent,
-        categoryBreakdown: attempt.result.categoryBreakdown,
+        categoryBreakdown: parseCategoryBreakdown(
+          attempt.result.categoryBreakdown,
+        ),
       }
     : null,
 });
@@ -103,9 +106,7 @@ export const GET = async (request: Request): Promise<NextResponse> => {
       },
     });
 
-    const data = pagedAttempts.map((attempt) =>
-      toAttemptSummary(attempt as AttemptWithResult),
-    );
+    const data = pagedAttempts.map(toAttemptSummary);
 
     return NextResponse.json({
       attempts: data,
@@ -117,10 +118,10 @@ export const GET = async (request: Request): Promise<NextResponse> => {
       },
       summary: {
         latestCompleted: latestCompleted
-          ? toAttemptSummary(latestCompleted as AttemptWithResult)
+          ? toAttemptSummary(latestCompleted)
           : null,
         latestInProgress: latestInProgress
-          ? toAttemptSummary(latestInProgress as AttemptWithResult)
+          ? toAttemptSummary(latestInProgress)
           : null,
       },
     });

--- a/app/me/components/attempt-detail-view.tsx
+++ b/app/me/components/attempt-detail-view.tsx
@@ -1,4 +1,6 @@
-import type { AttemptDetail, CategoryScore } from "../types";
+import type { CategoryScore } from "@/lib/quiz/types";
+
+import type { AttemptDetail } from "../types";
 
 type Props = {
   attempt: AttemptDetail;
@@ -24,7 +26,7 @@ export const AttemptDetailView = ({ attempt }: Props) => {
             カテゴリ別正答率
           </h3>
           <div className="space-y-2">
-            {(attempt.result.categoryBreakdown as CategoryScore[]).map((cat) => (
+            {attempt.result.categoryBreakdown.map((cat: CategoryScore) => (
               <div key={cat.category} className="flex items-center gap-3">
                 <span className="w-28 shrink-0 text-sm text-neutral-600 dark:text-neutral-400">
                   {cat.category}
@@ -71,7 +73,7 @@ export const AttemptDetailView = ({ attempt }: Props) => {
               <p className="mb-3 text-sm leading-relaxed">{q.question.questionText}</p>
 
               <div className="mb-3 flex flex-col gap-1.5">
-                {(q.question.choices as string[]).map((choice, i) => {
+                {q.question.choices.map((choice, i) => {
                   const isAnswer = i === q.question.answerIndex;
                   const isUserChoice = i === q.selectedIndex;
 

--- a/app/me/types.ts
+++ b/app/me/types.ts
@@ -1,9 +1,4 @@
-export type CategoryScore = {
-  category: string;
-  total: number;
-  correct: number;
-  percent: number;
-};
+import type { CategoryScore } from "@/lib/quiz/types";
 
 export type AttemptFilters = {
   categories?: string[];

--- a/app/quiz/[attemptId]/quiz-runner.tsx
+++ b/app/quiz/[attemptId]/quiz-runner.tsx
@@ -3,6 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import type { CategoryScore } from "@/lib/quiz/types";
+
 type QuestionData = {
   attemptQuestionId: string;
   order: number;
@@ -17,13 +19,6 @@ type QuestionData = {
     answerIndex?: number;
     explanation?: string;
   };
-};
-
-type CategoryScore = {
-  category: string;
-  total: number;
-  correct: number;
-  percent: number;
 };
 
 type ResultData = {
@@ -344,7 +339,7 @@ export const QuizRunner = ({ attemptId }: Props) => {
           aria-label={`問題 ${currentIndex + 1} の選択肢`}
           className="flex flex-col gap-3"
         >
-          {(currentQuestion.question.choices as string[]).map(
+          {currentQuestion.question.choices.map(
             (choice, index) => {
               const canAnswer =
                 currentQuestion.selectedIndex === null && !isSubmitting;
@@ -501,7 +496,7 @@ const ResultView = ({ attempt }: { attempt: AttemptData }) => {
 
   if (!result) return null;
 
-  const breakdown = result.categoryBreakdown as CategoryScore[];
+  const breakdown = result.categoryBreakdown;
 
   return (
     <div className="mx-auto w-full max-w-2xl space-y-6">
@@ -575,7 +570,7 @@ const ResultView = ({ attempt }: { attempt: AttemptData }) => {
             </p>
 
             <div className="mb-3 flex flex-col gap-1.5">
-              {(q.question.choices as string[]).map((choice, i) => {
+              {q.question.choices.map((choice, i) => {
                 const isAnswer = i === q.question.answerIndex;
                 const isUserChoice = i === q.selectedIndex;
 

--- a/lib/quiz/parsers.ts
+++ b/lib/quiz/parsers.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+import type { CategoryScore } from "@/lib/quiz/types";
+
+const choicesSchema = z.array(z.string());
+
+const categoryScoreSchema = z.object({
+  category: z.string(),
+  total: z.number(),
+  correct: z.number(),
+  percent: z.number(),
+});
+
+const categoryBreakdownSchema = z.array(categoryScoreSchema);
+
+export const parseQuestionChoices = (value: unknown): string[] => {
+  const parsed = choicesSchema.safeParse(value);
+  return parsed.success ? parsed.data : [];
+};
+
+export const parseCategoryBreakdown = (value: unknown): CategoryScore[] => {
+  const parsed = categoryBreakdownSchema.safeParse(value);
+  return parsed.success ? parsed.data : [];
+};

--- a/lib/quiz/scoring.ts
+++ b/lib/quiz/scoring.ts
@@ -1,13 +1,8 @@
+import type { CategoryScore } from "@/lib/quiz/types";
+
 type ScoringQuestion = {
   isCorrect: boolean | null;
   category: string;
-};
-
-type CategoryScore = {
-  category: string;
-  total: number;
-  correct: number;
-  percent: number;
 };
 
 type ScoringResult = {

--- a/lib/quiz/types.ts
+++ b/lib/quiz/types.ts
@@ -1,0 +1,6 @@
+export type CategoryScore = {
+  category: string;
+  total: number;
+  correct: number;
+  percent: number;
+};


### PR DESCRIPTION
## Summary
- `CategoryScore` を `lib/quiz/types.ts` に集約し、重複定義を解消
- `lib/quiz/parsers.ts` を追加し、API境界で `choices` / `categoryBreakdown` を検証して安全な型へ変換
- フロントと export API の `as string[]` / `as CategoryScore[]` キャストを除去

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `rg "as string\\[\\]|as CategoryScore\\[\\]"` で0件確認
- [x] `rg "type CategoryScore ="` が `lib/quiz/types.ts` のみであることを確認

## Related
- Closes #119

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation and safe parsing of quiz attempt data, including question choices and category score breakdowns, to ensure more reliable and consistent data handling across API endpoints and user interface components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->