### PR TITLE
fix(app): ローディングと動的メッセージのaria-live対応

### DIFF
--- a/app/me/me-dashboard.tsx
+++ b/app/me/me-dashboard.tsx
@@ -491,7 +491,9 @@ export const MeDashboard = () => {
   if (isLoading) {
     return (
       <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
-        <p className="text-sm text-neutral-600 dark:text-neutral-300">読み込み中...</p>
+        <p role="status" aria-live="polite" className="text-sm text-neutral-600 dark:text-neutral-300">
+          読み込み中...
+        </p>
       </section>
     );
   }
@@ -803,7 +805,12 @@ export const MeDashboard = () => {
                           : "Notionへ送信"}
                       </button>
                     </div>
-                    <div className="flex flex-col items-end gap-1">
+                    <div
+                      role="status"
+                      aria-live="polite"
+                      aria-atomic="true"
+                      className="flex flex-col items-end gap-1"
+                    >
                       {exportState?.message && (
                         <span
                           className={`text-xs ${
@@ -874,7 +881,9 @@ export const MeDashboard = () => {
       {/* 詳細表示 */}
       {isDetailLoading && (
         <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
-          <p className="text-sm text-neutral-600 dark:text-neutral-300">読み込み中...</p>
+          <p role="status" aria-live="polite" className="text-sm text-neutral-600 dark:text-neutral-300">
+            読み込み中...
+          </p>
         </section>
       )}
 

--- a/app/quiz/[attemptId]/quiz-runner.tsx
+++ b/app/quiz/[attemptId]/quiz-runner.tsx
@@ -259,7 +259,11 @@ export const QuizRunner = ({ attemptId }: Props) => {
   if (isLoading) {
     return (
       <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
-        <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        <p
+          role="status"
+          aria-live="polite"
+          className="text-sm text-neutral-600 dark:text-neutral-300"
+        >
           読み込み中...
         </p>
       </section>

--- a/app/select/select-form.tsx
+++ b/app/select/select-form.tsx
@@ -113,7 +113,11 @@ export const SelectForm = () => {
   if (isLoading) {
     return (
       <section className="rounded-2xl border border-black/10 bg-white p-6 dark:border-white/15 dark:bg-black/50">
-        <p className="text-sm text-neutral-600 dark:text-neutral-300">
+        <p
+          role="status"
+          aria-live="polite"
+          className="text-sm text-neutral-600 dark:text-neutral-300"
+        >
           読み込み中...
         </p>
       </section>


### PR DESCRIPTION
## Summary
- `/select` と `/quiz/[attemptId]` のローディング文言に `role=\"status\"` と `aria-live=\"polite\"` を追加
- `/me` 初期読み込み・詳細読み込みのローディング文言にも同様のライブリージョンを追加
- `/me` の履歴行で表示される export / Notion 送信メッセージ領域を `aria-live` 対応し、動的更新を読み上げ可能に変更

## Test plan
- [x] `npm run lint`
- [x] ローディング表示と履歴メッセージ領域に `aria-live` 属性が付与されていることをコード上で確認

## Related
- Closes #120

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Enhanced screen reader support for loading indicators across the dashboard, quiz runner, and form pages. Users relying on assistive technologies now receive clearer feedback during content loading and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->