### PR TITLE
feat(db): Issue #132 DB拡張で複数選択対応の土台を追加

### DIFF
--- a/prisma/migrations/20260304000100_add_question_type_and_multi_answer_support/migration.sql
+++ b/prisma/migrations/20260304000100_add_question_type_and_multi_answer_support/migration.sql
@@ -1,0 +1,12 @@
+CREATE TYPE "QuestionType" AS ENUM ('SINGLE', 'MULTIPLE');
+
+ALTER TABLE "Question"
+ADD COLUMN "questionType" "QuestionType" NOT NULL DEFAULT 'SINGLE',
+ADD COLUMN "answerIndices" JSONB;
+
+ALTER TABLE "AttemptQuestion"
+ADD COLUMN "selectedIndices" JSONB;
+
+UPDATE "Question"
+SET "answerIndices" = jsonb_build_array("answerIndex")
+WHERE "answerIndices" IS NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,11 @@ enum NotionDeliveryJobStatus {
   FAILED
 }
 
+enum QuestionType {
+  SINGLE
+  MULTIPLE
+}
+
 model User {
   id           String    @id @default(cuid())
   email        String    @unique
@@ -34,9 +39,11 @@ model Question {
   id               String            @id @default(cuid())
   category         String
   level            Int
+  questionType     QuestionType      @default(SINGLE)
   questionText     String
   choices          Json
   answerIndex      Int
+  answerIndices    Json?
   explanation      String
   createdAt        DateTime          @default(now())
   updatedAt        DateTime          @updatedAt
@@ -70,6 +77,7 @@ model AttemptQuestion {
   order        Int
   choiceOrder  Json?
   selectedIndex Int?
+  selectedIndices Json?
   isCorrect    Boolean?
   answeredAt   DateTime?
   createdAt    DateTime  @default(now())

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -358,9 +358,11 @@ const main = async (): Promise<void> => {
     data: seedQuestions.map((question) => ({
       category: question.category,
       level: question.level,
+      questionType: "SINGLE",
       questionText: question.questionText,
       choices: question.choices as Prisma.JsonArray,
       answerIndex: question.answerIndex,
+      answerIndices: [question.answerIndex] as Prisma.JsonArray,
       explanation: question.explanation,
     })),
   });


### PR DESCRIPTION
## Summary
- `prisma/schema.prisma` を拡張し、単一/複数選択対応のための新規フィールドを追加
  - `QuestionType` enum（`SINGLE` / `MULTIPLE`）
  - `Question.questionType`（default: `SINGLE`）
  - `Question.answerIndices`（JSON）
  - `AttemptQuestion.selectedIndices`（JSON）
- migration を追加
  - `QuestionType` enum 作成
  - 新規カラム追加
  - 既存データの `answerIndices` を `answerIndex` から初期化
- `prisma/seed.ts` を互換更新
  - 既存問題を `SINGLE` として投入
  - `answerIndices` に単一正解を配列で投入

## Test plan
- [x] `npx prisma generate`
- [x] `npm run lint`
- [x] `npm run build`

## Related
- Refs #130
- Closes #132

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Questions now support both single-answer and multiple-answer formats
  * Added ability to track and configure multiple correct answers for questions
  * Enhanced selection tracking for improved quiz functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->