### PR TITLE
feat(api): Issue #133 single/multiple回答のAPI両対応

### DIFF
--- a/app/api/attempts/[attemptId]/answer/route.ts
+++ b/app/api/attempts/[attemptId]/answer/route.ts
@@ -8,9 +8,22 @@ import {
 } from "@/lib/api/guards";
 import { messageResponse, internalServerErrorResponse } from "@/lib/auth/http";
 import { prisma } from "@/lib/db/prisma";
+import { parseQuestionChoices, parseQuestionIndices } from "@/lib/quiz/parsers";
 
 type RouteContext = {
   params: Promise<{ attemptId: string }>;
+};
+
+const isSingleQuestionType = (questionType: string): boolean => {
+  return questionType === "SINGLE";
+};
+
+const areSameIndexSet = (left: number[], right: number[]): boolean => {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
 };
 
 export const POST = async (
@@ -71,12 +84,19 @@ export const POST = async (
       );
     }
 
-    const { attemptQuestionId, selectedIndex } = parsed.data;
+    const { attemptQuestionId, selectedIndex, selectedIndices } = parsed.data;
 
     const attemptQuestion = await prisma.attemptQuestion.findUnique({
       where: { id: attemptQuestionId },
       include: {
-        question: { select: { answerIndex: true } },
+        question: {
+          select: {
+            answerIndex: true,
+            answerIndices: true,
+            questionType: true,
+            choices: true,
+          },
+        },
       },
     });
 
@@ -84,16 +104,87 @@ export const POST = async (
       return messageResponse("question not found", 404);
     }
 
-    if (attemptQuestion.selectedIndex !== null) {
+    if (
+      attemptQuestion.selectedIndex !== null ||
+      attemptQuestion.selectedIndices !== null
+    ) {
       return messageResponse("この問題は既に回答済みです", 400);
     }
 
-    const isCorrect = selectedIndex === attemptQuestion.question.answerIndex;
+    const parsedChoices = parseQuestionChoices(attemptQuestion.question.choices);
+    const choiceCount = parsedChoices.length;
+    if (choiceCount === 0) {
+      return messageResponse("問題データが不正です", 400);
+    }
+
+    const normalizedCorrectIndices = parseQuestionIndices(
+      attemptQuestion.question.answerIndices,
+      choiceCount,
+    );
+    const correctIndices =
+      normalizedCorrectIndices.length > 0
+        ? normalizedCorrectIndices
+        : [attemptQuestion.question.answerIndex];
+
+    if (isSingleQuestionType(attemptQuestion.question.questionType)) {
+      if (selectedIndex === undefined || selectedIndices !== undefined) {
+        return messageResponse(
+          "単一選択問題は selectedIndex を指定してください",
+          400,
+        );
+      }
+
+      if (selectedIndex < 0 || selectedIndex >= choiceCount) {
+        return messageResponse("selectedIndex が不正です", 400);
+      }
+
+      const isCorrect = selectedIndex === attemptQuestion.question.answerIndex;
+      const updated = await prisma.attemptQuestion.update({
+        where: { id: attemptQuestionId },
+        data: {
+          selectedIndex,
+          selectedIndices: [selectedIndex],
+          isCorrect,
+          answeredAt: new Date(),
+        },
+      });
+
+      return NextResponse.json({
+        attemptQuestionId: updated.id,
+        selectedIndex: updated.selectedIndex,
+        selectedIndices: [selectedIndex],
+      });
+    }
+
+    if (selectedIndices === undefined || selectedIndex !== undefined) {
+      return messageResponse(
+        "複数選択問題は selectedIndices を指定してください",
+        400,
+      );
+    }
+
+    const normalizedSelectedIndices = parseQuestionIndices(
+      selectedIndices,
+      choiceCount,
+    );
+    if (normalizedSelectedIndices.length === 0) {
+      return messageResponse("selectedIndices が不正です", 400);
+    }
+
+    if (normalizedSelectedIndices.length !== selectedIndices.length) {
+      return messageResponse(
+        "selectedIndices に重複または範囲外の値が含まれています",
+        400,
+      );
+    }
+
+    const isCorrect = areSameIndexSet(normalizedSelectedIndices, correctIndices);
 
     const updated = await prisma.attemptQuestion.update({
       where: { id: attemptQuestionId },
       data: {
-        selectedIndex,
+        selectedIndex: null,
+        selectedIndices: normalizedSelectedIndices,
         isCorrect,
         answeredAt: new Date(),
       },
@@ -102,6 +193,7 @@ export const POST = async (
     return NextResponse.json({
       attemptQuestionId: updated.id,
       selectedIndex: updated.selectedIndex,
+      selectedIndices: normalizedSelectedIndices,
     });
   } catch (error) {
     return internalServerErrorResponse(error);

--- a/app/api/attempts/[attemptId]/finalize/route.ts
+++ b/app/api/attempts/[attemptId]/finalize/route.ts
@@ -9,6 +9,7 @@ import {
   createAttemptFinalizedEvent,
   logAttemptFinalizedEvent,
 } from "@/lib/logging/attempt-events";
+import { parseQuestionIndices, parseQuestionChoices } from "@/lib/quiz/parsers";
 import { calculateScore } from "@/lib/quiz/scoring";
 
 type RouteContext = {
@@ -46,7 +47,15 @@ export const POST = async (
       include: {
         questions: {
           include: {
-            question: { select: { category: true, answerIndex: true } },
+            question: {
+              select: {
+                category: true,
+                answerIndex: true,
+                answerIndices: true,
+                questionType: true,
+                choices: true,
+              },
+            },
           },
         },
         result: true,
@@ -65,9 +74,27 @@ export const POST = async (
       return messageResponse("この試験は既に採点済みです", 400);
     }
 
-    const unanswered = attempt.questions.filter(
-      (aq) => aq.selectedIndex === null,
-    );
+    const unanswered = attempt.questions.filter((aq) => {
+      const choiceCount = parseQuestionChoices(aq.question.choices).length;
+      if (choiceCount === 0) {
+        return true;
+      }
+
+      const parsedSelectedIndices = parseQuestionIndices(
+        aq.selectedIndices,
+        choiceCount,
+      );
+
+      if (aq.question.questionType === "MULTIPLE") {
+        return parsedSelectedIndices.length === 0;
+      }
+
+      if (aq.selectedIndex !== null) {
+        return false;
+      }
+
+      return parsedSelectedIndices.length !== 1;
+    });
 
     if (unanswered.length > 0) {
       return messageResponse(

--- a/app/api/attempts/[attemptId]/route.ts
+++ b/app/api/attempts/[attemptId]/route.ts
@@ -7,6 +7,7 @@ import { prisma } from "@/lib/db/prisma";
 import {
   parseCategoryBreakdown,
   parseChoiceOrder,
+  parseQuestionIndices,
   parseQuestionChoices,
 } from "@/lib/quiz/parsers";
 
@@ -46,9 +47,11 @@ export const GET = async (
                 id: true,
                 category: true,
                 level: true,
+                questionType: true,
                 questionText: true,
                 choices: true,
                 answerIndex: true,
+                answerIndices: true,
                 explanation: true,
               },
             },
@@ -68,28 +71,49 @@ export const GET = async (
 
     const questions = attempt.questions.map((aq) => {
       const parsedChoices = parseQuestionChoices(aq.question.choices);
+      const parsedAnswerIndices = parseQuestionIndices(
+        aq.question.answerIndices,
+        parsedChoices.length,
+      );
+      const answerIndices =
+        parsedAnswerIndices.length > 0
+          ? parsedAnswerIndices
+          : [aq.question.answerIndex];
+      const parsedSelectedIndices = parseQuestionIndices(
+        aq.selectedIndices,
+        parsedChoices.length,
+      );
+      const selectedIndices =
+        parsedSelectedIndices.length > 0
+          ? parsedSelectedIndices
+          : aq.selectedIndex !== null
+            ? [aq.selectedIndex]
+            : null;
 
       return {
-      attemptQuestionId: aq.id,
-      order: aq.order,
-      choiceOrder: parseChoiceOrder(aq.choiceOrder, parsedChoices.length),
-      selectedIndex: aq.selectedIndex,
-      isCorrect: aq.isCorrect,
-      answeredAt: aq.answeredAt,
-      question: {
-        id: aq.question.id,
-        category: aq.question.category,
-        level: aq.question.level,
-        questionText: aq.question.questionText,
-        choices: parsedChoices,
-        ...(attempt.status === "COMPLETED"
-          ? {
-              answerIndex: aq.question.answerIndex,
-              explanation: aq.question.explanation,
-            }
-          : {}),
-      },
-    };
+        attemptQuestionId: aq.id,
+        order: aq.order,
+        choiceOrder: parseChoiceOrder(aq.choiceOrder, parsedChoices.length),
+        selectedIndex: aq.selectedIndex,
+        selectedIndices,
+        isCorrect: aq.isCorrect,
+        answeredAt: aq.answeredAt,
+        question: {
+          id: aq.question.id,
+          category: aq.question.category,
+          level: aq.question.level,
+          questionType: aq.question.questionType,
+          questionText: aq.question.questionText,
+          choices: parsedChoices,
+          ...(attempt.status === "COMPLETED"
+            ? {
+                answerIndex: aq.question.answerIndex,
+                answerIndices,
+                explanation: aq.question.explanation,
+              }
+            : {}),
+        },
+      };
     });
 
     return NextResponse.json({

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -480,7 +480,7 @@ components:
 
     CreateAttemptRequest:
       type: object
-      required: [categories, level, numQuestions]
+      required: [categories, level, count]
       properties:
         categories:
           type: array
@@ -492,9 +492,10 @@ components:
         level:
           type: integer
           enum: [1, 2, 3]
-        numQuestions:
+        count:
           type: integer
           minimum: 1
+          maximum: 50
 
     CreateAttemptResponse:
       type: object
@@ -505,7 +506,7 @@ components:
 
     AnswerAttemptRequest:
       type: object
-      required: [attemptQuestionId, selectedIndex]
+      required: [attemptQuestionId]
       properties:
         attemptQuestionId:
           type: string
@@ -514,16 +515,30 @@ components:
         selectedIndex:
           type: integer
           minimum: 0
-          maximum: 3
+        selectedIndices:
+          type: array
+          minItems: 1
+          items:
+            type: integer
+            minimum: 0
+      oneOf:
+        - required: [selectedIndex]
+        - required: [selectedIndices]
 
     AnswerAttemptResponse:
       type: object
-      required: [attemptQuestionId, selectedIndex]
+      required: [attemptQuestionId]
       properties:
         attemptQuestionId:
           type: string
         selectedIndex:
           type: integer
+          nullable: true
+        selectedIndices:
+          type: array
+          nullable: true
+          items:
+            type: integer
 
     CategoryBreakdownItem:
       type: object
@@ -559,22 +574,45 @@ components:
             type: string
           example: [VPC, EC2, S3, IAM, RDS, Lambda]
 
-    AttemptQuestionItem:
+    QuestionDetail:
       type: object
-      required: [id, questionId, order, questionText, choices]
+      required: [id, category, level, questionType, questionText, choices]
       properties:
         id:
           type: string
-        questionId:
+        category:
           type: string
-        order:
+        level:
           type: integer
+        questionType:
+          type: string
+          enum: [SINGLE, MULTIPLE]
         questionText:
           type: string
         choices:
           type: array
           items:
             type: string
+        answerIndex:
+          type: integer
+          description: COMPLETED時のみ返却（single互換）
+        answerIndices:
+          type: array
+          description: COMPLETED時のみ返却（single/multiple共通）
+          items:
+            type: integer
+        explanation:
+          type: string
+          description: COMPLETED時のみ返却
+
+    AttemptQuestionItem:
+      type: object
+      required: [attemptQuestionId, order, question]
+      properties:
+        attemptQuestionId:
+          type: string
+        order:
+          type: integer
         choiceOrder:
           type: array
           description: 選択肢表示順（表示インデックス→元のchoicesインデックス）
@@ -583,18 +621,21 @@ components:
         selectedIndex:
           type: integer
           nullable: true
+        selectedIndices:
+          type: array
+          nullable: true
+          items:
+            type: integer
         isCorrect:
           type: boolean
           nullable: true
           description: COMPLETED時のみ非null（IN_PROGRESS中はnull）
-        answerIndex:
-          type: integer
-          description: COMPLETED時のみ返却
-        explanation:
+        answeredAt:
           type: string
-          description: COMPLETED時のみ返却
-        category:
-          type: string
+          format: date-time
+          nullable: true
+        question:
+          $ref: "#/components/schemas/QuestionDetail"
 
     AttemptDetailResponse:
       type: object

--- a/lib/attempt/schemas.ts
+++ b/lib/attempt/schemas.ts
@@ -23,7 +23,20 @@ export const createAttemptSchema = z.object({
 
 export const answerSchema = z.object({
   attemptQuestionId: z.string().min(1).max(100, "attemptQuestionId is too long"),
-  selectedIndex: z.number().int().min(0).max(3),
+  selectedIndex: z.number().int().min(0).optional(),
+  selectedIndices: z.array(z.number().int().min(0)).min(1).optional(),
+}).superRefine((value, context) => {
+  const hasSelectedIndex = value.selectedIndex !== undefined;
+  const hasSelectedIndices = value.selectedIndices !== undefined;
+
+  if (hasSelectedIndex === hasSelectedIndices) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "selectedIndex か selectedIndices のいずれか一方のみ指定してください",
+      path: ["selectedIndex"],
+    });
+  }
 });
 
 export const attemptsQuerySchema = z.object({

--- a/lib/quiz/parsers.ts
+++ b/lib/quiz/parsers.ts
@@ -12,6 +12,7 @@ const categoryScoreSchema = z.object({
 });
 
 const categoryBreakdownSchema = z.array(categoryScoreSchema);
+const indicesSchema = z.array(z.number().int().nonnegative());
 
 export const parseQuestionChoices = (value: unknown): string[] => {
   const parsed = choicesSchema.safeParse(value);
@@ -44,6 +45,29 @@ export const parseChoiceOrder = (
   }
 
   return parsed.data;
+};
+
+export const parseQuestionIndices = (
+  value: unknown,
+  choicesCount: number,
+): number[] => {
+  if (choicesCount <= 0) {
+    return [];
+  }
+
+  const parsed = indicesSchema.safeParse(value);
+  if (!parsed.success || parsed.data.length === 0) {
+    return [];
+  }
+
+  const hasOutOfRange = parsed.data.some(
+    (index) => index < 0 || index >= choicesCount,
+  );
+  if (hasOutOfRange) {
+    return [];
+  }
+
+  return [...new Set(parsed.data)].sort((a, b) => a - b);
 };
 
 export const parseCategoryBreakdown = (value: unknown): CategoryScore[] => {


### PR DESCRIPTION
## Summary
- `POST /api/attempts/{attemptId}/answer` を拡張し、`selectedIndex`（single）または `selectedIndices`（multiple）の入力を受け付けるように変更
- `GET /api/attempts/{attemptId}` に `questionType` / `selectedIndices` / `answerIndices` を追加し、single/multiple を判別可能に更新
- `POST /api/attempts/{attemptId}/finalize` の未回答判定を single/multiple 両対応に更新
- Zod schema（`answerSchema`）を「どちらか一方指定」バリデーションへ更新
- OpenAPI を実装に合わせて更新（Answer request/response、Attempt detail、CreateAttemptRequestの`count`整合）

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `ReadLints` で変更ファイルの診断エラーなしを確認

## Related
- Refs #130
- Closes #133

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for quiz questions with multiple correct answers; users can now submit multiple selections when answering applicable questions.

* **Bug Fixes**
  * Improved validation to prevent re-answering already answered questions.

* **Documentation**
  * Updated API specifications with revised parameter names and new response fields to support multi-answer selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->