### PR TITLE
Issue #153: カテゴリAPIとAttempt作成を platform / exam 対応

### DIFF
--- a/app/api/attempts/create/route.ts
+++ b/app/api/attempts/create/route.ts
@@ -61,10 +61,22 @@ export const POST = async (request: Request): Promise<NextResponse> => {
       );
     }
 
-    const { categories, level, levels, count, preset } = parsed.data;
+    const {
+      categories,
+      level,
+      levels,
+      count,
+      preset,
+      platform: requestedPlatform,
+      exam: requestedExam,
+    } = parsed.data;
+    const platform = preset === "cloud-practitioner" ? "AWS" : requestedPlatform;
+    const exam = preset === "cloud-practitioner" ? "CP" : requestedExam;
 
     const questions = await prisma.question.findMany({
       where: {
+        ...(platform ? { platform } : {}),
+        ...(exam ? { exam } : {}),
         category: { in: categories },
         level: level !== undefined ? level : { in: levels ?? [] },
       },
@@ -93,6 +105,8 @@ export const POST = async (request: Request): Promise<NextResponse> => {
             count,
             ...(level !== undefined ? { level } : {}),
             ...(levels !== undefined ? { levels } : {}),
+            ...(platform ? { platform } : {}),
+            ...(exam ? { exam } : {}),
             ...(preset ? { preset } : {}),
           },
         },

--- a/app/api/questions/categories/route.ts
+++ b/app/api/questions/categories/route.ts
@@ -12,19 +12,39 @@ export const GET = async (request: Request): Promise<NextResponse> => {
       return messageResponse("unauthorized", 401);
     }
 
+    const url = new URL(request.url);
+    const platform = url.searchParams.get("platform")?.trim() || undefined;
+    const exam = url.searchParams.get("exam")?.trim() || undefined;
+
     const rows = await prisma.question.groupBy({
-      by: ["category", "level"],
+      by: ["platform", "exam", "category", "level"],
+      where: {
+        ...(platform ? { platform } : {}),
+        ...(exam ? { exam } : {}),
+      },
       _count: { id: true },
-      orderBy: [{ category: "asc" }, { level: "asc" }],
+      orderBy: [
+        { platform: "asc" },
+        { exam: "asc" },
+        { category: "asc" },
+        { level: "asc" },
+      ],
     });
 
     const categoryMap = new Map<
       string,
-      { category: string; levels: number[]; count: number }
+      {
+        platform: string;
+        exam: string;
+        category: string;
+        levels: number[];
+        count: number;
+      }
     >();
 
     for (const row of rows) {
-      const existing = categoryMap.get(row.category);
+      const key = `${row.platform}::${row.exam}::${row.category}`;
+      const existing = categoryMap.get(key);
 
       if (existing) {
         if (!existing.levels.includes(row.level)) {
@@ -32,7 +52,9 @@ export const GET = async (request: Request): Promise<NextResponse> => {
         }
         existing.count += row._count.id;
       } else {
-        categoryMap.set(row.category, {
+        categoryMap.set(key, {
+          platform: row.platform,
+          exam: row.exam,
           category: row.category,
           levels: [row.level],
           count: row._count.id,

--- a/app/me/types.ts
+++ b/app/me/types.ts
@@ -1,6 +1,8 @@
 import type { CategoryScore } from "@/lib/quiz/types";
 
 export type AttemptFilters = {
+  platform?: string;
+  exam?: string;
   categories?: string[];
   level?: number;
   levels?: number[];

--- a/lib/attempt/schemas.ts
+++ b/lib/attempt/schemas.ts
@@ -13,6 +13,8 @@ export const attemptParamsSchema = z.object({
 });
 
 export const createAttemptSchema = z.object({
+  platform: z.string().trim().min(1).max(100, "platform が長すぎます").optional(),
+  exam: z.string().trim().min(1).max(100, "exam が長すぎます").optional(),
   categories: z
     .array(z.string().min(1).max(200, "カテゴリ名が長すぎます"))
     .min(1, "カテゴリを1つ以上選択してください")


### PR DESCRIPTION
## Summary
- `GET /api/questions/categories` に `platform` / `exam` クエリフィルタを追加し、レスポンスにも `platform` / `exam` を含めるよう更新
- `POST /api/attempts/create` の問題抽出条件に `platform` / `exam` を追加
- Cloud Practitioner プリセット時に `platform: AWS` / `exam: CP` をサーバー側で明示適用
- `createAttemptSchema` と履歴フィルタ型に `platform` / `exam` を追加

Closes #153

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [ ] `GET /api/questions/categories?platform=AWS&exam=CP` が絞り込み結果を返すこと
- [ ] Cloud Practitioner開始時の `Attempt.filters` に `platform/exam` が記録されること

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform and exam filtering options for attempts.
  * Question categories are now organized and sortable by platform and exam.
  * Attempt creation now accepts optional platform and exam parameters with validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->