### PR TITLE
fix: ActivityHeatmapのワイド画面余白を改善（#178）

### DIFF
--- a/app/me/components/activity-heatmap.tsx
+++ b/app/me/components/activity-heatmap.tsx
@@ -78,7 +78,7 @@ export const ActivityHeatmap = ({ items }: Props) => {
         {totalContributions.toLocaleString("en-US")} contributions in the last year
       </p>
       <div className="overflow-x-auto pb-1">
-        <div className="min-w-max rounded-lg border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-700 dark:bg-neutral-900/40">
+        <div className="mx-auto w-fit min-w-max rounded-lg border border-neutral-200 bg-neutral-50 p-2 dark:border-neutral-700 dark:bg-neutral-900/40">
           <div className="flex flex-col gap-2">
             <div
               className="ml-7 grid"


### PR DESCRIPTION
## Summary
- `ActivityHeatmap` のヒートマップ本体コンテナを `mx-auto w-fit min-w-max` に変更し、ワイド画面で右側余白が偏って見える問題を改善
- 既存の横スクロール挙動（狭い画面での `overflow-x-auto`）は維持
- 変更は `app/me/components/activity-heatmap.tsx` のレイアウト調整のみ

## Test plan
- [x] `npm run lint`
- [ ] `/me` をワイド画面で表示し、ヒートマップがカード内で中央寄せされること
- [ ] 画面幅を狭めたときに、横スクロールで表示が維持されること
- [ ] 表示内容（マス数・ラベル・色分け）に回帰がないこと

Closes #178

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Centered the activity heatmap card for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->