### PR TITLE
feat: LinuC seed追加と/selectプラットフォーム表示改善（#179）

### DIFF
--- a/app/select/select-form.tsx
+++ b/app/select/select-form.tsx
@@ -252,7 +252,11 @@ export const SelectForm = () => {
               <label className="mb-2 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
                 プラットフォーム
               </label>
-              <div role="group" aria-label="プラットフォーム選択" className="flex flex-wrap gap-2">
+              <div
+                role="group"
+                aria-label="プラットフォーム選択"
+                className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4"
+              >
                 {platforms.map((platform) => (
                   <button
                     key={platform}
@@ -263,7 +267,7 @@ export const SelectForm = () => {
                       setError("");
                     }}
                     aria-pressed={selectedPlatform === platform}
-                    className={`min-h-[44px] rounded-lg border px-4 py-2.5 text-sm font-medium transition sm:min-h-0 sm:py-2 ${
+                    className={`min-h-[44px] w-full rounded-lg border px-4 py-2.5 text-center text-sm font-medium transition sm:min-h-0 sm:py-2 ${
                       selectedPlatform === platform
                         ? "border-brand-400 bg-brand-200/40 text-brand-700 dark:border-brand-300 dark:bg-brand-400/20 dark:text-brand-200"
                         : "border-neutral-300 text-neutral-600 hover:border-neutral-400 dark:border-neutral-600 dark:text-neutral-400 dark:hover:border-neutral-500"

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -396,6 +396,96 @@ const seedQuestions: SeedQuestion[] = [
     explanation:
       "予約済み同時実行により、特定関数のスロット確保や制限ができます。",
   },
+  {
+    platform: "LinuC",
+    exam: "101",
+    category: "Linux基礎",
+    level: 1,
+    questionText:
+      "Linuxカーネルを含むOSを無償で配布し、改変・再配布も可能とする考え方はどれですか？",
+    choices: ["プロプライエタリ", "オープンソース", "シェアウェア", "フリーウェアのみ"],
+    answerIndex: 1,
+    explanation:
+      "Linuxはオープンソースソフトウェアとして、ライセンス条件のもと改変や再配布が可能です。",
+  },
+  {
+    platform: "LinuC",
+    exam: "101",
+    category: "Linux基礎",
+    level: 2,
+    questionText:
+      "現在の作業ディレクトリを表示するために使うコマンドはどれですか？",
+    choices: ["ls", "pwd", "cd", "whoami"],
+    answerIndex: 1,
+    explanation: "`pwd` は現在の作業ディレクトリの絶対パスを表示します。",
+  },
+  {
+    platform: "LinuC",
+    exam: "101",
+    category: "Linux基礎",
+    level: 3,
+    questionText:
+      "ホームディレクトリ配下の `logs` ディレクトリを再帰的に作成するコマンドはどれですか？",
+    choices: [
+      "mkdir ~/logs",
+      "mkdir -p ~/logs",
+      "touch -p ~/logs",
+      "cp -r ~/logs",
+    ],
+    answerIndex: 1,
+    explanation:
+      "`mkdir -p` を使うと、必要な親ディレクトリも含めて再帰的に作成できます。",
+  },
+  {
+    platform: "LinuC",
+    exam: "101",
+    category: "ファイル操作",
+    level: 1,
+    questionText:
+      "ファイルのアクセス権を `644` に変更するコマンドとして正しいものはどれですか？",
+    choices: [
+      "chown 644 sample.txt",
+      "chmod 644 sample.txt",
+      "chgrp 644 sample.txt",
+      "umask 644 sample.txt",
+    ],
+    answerIndex: 1,
+    explanation: "アクセス権の変更には `chmod` コマンドを使用します。",
+  },
+  {
+    platform: "LinuC",
+    exam: "101",
+    category: "ファイル操作",
+    level: 2,
+    questionText:
+      "`/var/log/messages` の末尾をリアルタイム監視するコマンドとして適切なのはどれですか？",
+    choices: [
+      "cat /var/log/messages",
+      "tail -f /var/log/messages",
+      "head -f /var/log/messages",
+      "less -f /var/log/messages",
+    ],
+    answerIndex: 1,
+    explanation:
+      "`tail -f` はファイル末尾の追記を監視できるためログ監視でよく使われます。",
+  },
+  {
+    platform: "LinuC",
+    exam: "101",
+    category: "ファイル操作",
+    level: 3,
+    questionText:
+      "現在のディレクトリ配下から `conf` を含むファイル名を再帰検索するコマンドはどれですか？",
+    choices: [
+      "grep -r conf .",
+      "find . -name '*conf*'",
+      "ls -R conf",
+      "whereis conf",
+    ],
+    answerIndex: 1,
+    explanation:
+      "`find . -name '*conf*'` で再帰的にファイル名パターン検索ができます。",
+  },
 ];
 
 const main = async (): Promise<void> => {


### PR DESCRIPTION
## Summary
- `prisma/seed.ts` に LinuC (`exam: 101`) の問題を6問追加（カテゴリ: Linux基礎 / ファイル操作、各Lv.1-3）
- `/select` のプラットフォーム選択UIを `grid` レイアウト化し、複数プラットフォーム時の視認性を改善
- プラットフォームボタンを `w-full` にして行内揃えを安定化

## Test plan
- [x] `npm run db:seed`
- [x] `npm run lint`
- [ ] `/select` で `AWS` と `LinuC` が表示されること
- [ ] 画面幅（SP/Tablet/Desktop）でプラットフォーム選択UIが自然に折り返し表示されること
- [ ] プラットフォーム切り替え時にカテゴリ一覧が正しく切り替わること

Closes #179

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Platform selection interface reorganized into a responsive grid layout that automatically adjusts columns based on screen size for improved organization.

* **New Features**
  * Added 12 new practice questions covering Linux fundamentals, file operations, and command-line tasks to expand the question library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->